### PR TITLE
Add SAM 3 video tracking backend as alternative to background subtraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,39 @@ Motion-trail visualisation tool for tracking multiple objects in video — inclu
 
 ## Workflow
 
+Two interchangeable trackers write the same `*_tracking.json`, so everything
+downstream is shared:
+
 ```
 input video
     │
     ▼
 pick.py          ← interactively select objects and frame range
     │ rois.json
-    ▼
-track.py         ← background subtraction + Hungarian tracking
-    │ *_tracking.json + *_debug.mp4
-    ▼
-render.py        ← render persistent and transient trail videos
-    │ *_persistent.mp4 + *_transient.mp4
-    ▼
-to_webm.py       ← (optional) batch-convert output/*.mp4 → output/webm/
+    ├─────────────────────────┐
+    ▼                         ▼
+track.py                  track_sam3.py    ← SAM 3 (GPU); text prompts optional
+background subtraction    promptable segmentation + tracking
+    │                         │
+    └──────────┬──────────────┘
+               │ *_tracking.json + *_debug.mp4  (+ *_masks.npz from SAM 3)
+               ▼
+        render.py        ← render persistent and transient trail videos
+               │ *_persistent.mp4 + *_transient.mp4
+               ▼
+        to_webm.py       ← (optional) batch-convert output/*.mp4 → output/webm/
 ```
+
+Which tracker to use:
+
+| | `track.py` | `track_sam3.py` |
+|---|---|---|
+| Hardware | any laptop | CUDA GPU |
+| Camera | must be static | may move |
+| Setup | none | SAM 3 install + gated checkpoint |
+| Selecting objects | boxes in `rois.json` | boxes **or** a text prompt |
+| Output | centroids | centroids + masks |
+| Tiny/low-contrast objects | tuned sensitive mask | may need `--zoom-agents` |
 
 ## Setup
 
@@ -32,6 +50,14 @@ to_webm.py       ← (optional) batch-convert output/*.mp4 → output/webm/
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+```
+
+For the SAM 3 backend only (see [SAM 3 tracking](#sam-3-tracking-track_sam3py)):
+
+```bash
+pip install -r requirements-sam3.txt
+git clone https://github.com/facebookresearch/sam3 && pip install -e sam3
+python src/sam3_preflight.py     # verifies python/torch/CUDA/sam3
 ```
 
 ## Usage
@@ -67,6 +93,80 @@ Writes to `output/`:
 - `*_debug.mp4` — annotated video showing bounding boxes, labels, and trails
 - `*_tracking.json` — full per-frame coordinate log for all objects
 
+Pass `--no-display` to run without a GUI window (headless machines, remote boxes).
+`--video`, `--rois` and `--out` override the paths at the top of the file.
+
+### SAM 3 tracking (`track_sam3.py`)
+
+A drop-in alternative to step 2 that uses Meta's [SAM 3](https://github.com/facebookresearch/sam3)
+instead of background subtraction. It needs no background model, so it tolerates
+a moving camera and changing light, and it returns masks rather than blobs — so
+overlapping objects keep their own centroids.
+
+```bash
+python src/sam3_preflight.py                          # check the environment first
+python src/track_sam3.py --out output/crazyflo_sam3.mp4
+python src/render.py output/crazyflo_sam3_tracking.json
+```
+
+Because both trackers write the same JSON, you can render each and compare them
+on the same clip.
+
+**Choosing what to track.** Either seed from the boxes you already picked, which
+keeps your `cf1`/`cf2`/`cf3`/`payload` names:
+
+```bash
+python src/track_sam3.py --from-rois                   # default
+```
+
+…or describe the objects and let the detector find them. Discovered objects are
+named by first appearance (`obj0`, `obj1`, …) and can be renamed:
+
+```bash
+python src/track_sam3.py --text "drone" --name 0=cf1 --name 1=cf2
+```
+
+**Key options**
+
+| Option | Purpose |
+|---|---|
+| `--agents cf1,cf2` | track a subset of `rois.json` |
+| `--prompt-shape point` | seed with the ROI's centre point instead of its box |
+| `--point-mode bbox` | use bbox centres instead of mask barycentres |
+| `--reprompt-every N` | re-seed every N frames; also caps memory-bank VRAM on long clips |
+| `--min-score` / `--min-area` | drop weak or implausibly small detections |
+| `--zoom-agents payload` | re-track an agent through an upscaled crop (see below) |
+| `--borrow-agents payload --borrow-from <json>` | take that agent from another tracker's output |
+| `--save-masks` | write a `*_masks.npz` sidecar for mask-aware rendering |
+| `--no-gap-fill` | leave dropouts as holes instead of interpolating |
+
+**Quality reporting.** Every run logs per-object coverage, longest dropout,
+score range and mask area, and stores them under `sam3_stats` in the tracking
+JSON. Coverage is the number to watch: gap fill will happily draw a straight
+line through a stretch where the object was never actually found, and the trail
+video alone will not show you that.
+
+**Small, low-contrast objects.** A 26×34 px payload is ~0.04 % of a 1080p frame,
+which is where SAM 3 is weakest. Two fallbacks, in order of preference:
+
+```bash
+# 1. re-track it through a crop that is upscaled before it reaches the model
+python src/track_sam3.py --zoom-agents payload --zoom-crop 384 --zoom-upscale 3
+
+# 2. hybrid: SAM 3 for the drones, background subtraction for the payload
+python src/track.py --no-display                       # produces the donor JSON
+python src/track_sam3.py --borrow-agents payload \
+    --borrow-from output/crazyflo_path_tracking.json
+```
+
+**Tests.** The plumbing around the model — frame-index mapping, prompt dispatch,
+output normalisation, chunking, trail assembly, mask storage — is covered by a
+fake predictor and needs no GPU:
+
+```bash
+python -m unittest discover -s tests
+```
+
 **3. Render trails** — `src/render.py`
 
 ```bash
@@ -82,6 +182,22 @@ Reads the tracking JSON and produces two clean videos:
 
 Trail appearance (color, thickness, alpha, window length) can be overridden via the `OVERRIDES` dict at the top of the file without re-running tracking.
 
+If a `*_masks.npz` sidecar exists (written by `track_sam3.py --save-masks`), two
+extra render modes become available:
+
+```bash
+python src/render.py output/crazyflo_sam3_tracking.json --mask-mode occlude
+python src/render.py output/crazyflo_sam3_tracking.json --mask-mode glow
+```
+
+| Mode | Effect |
+|---|---|
+| `off` | default — trails drawn straight over the frame |
+| `occlude` | trails pass *behind* the objects |
+| `glow` | `occlude`, plus a coloured halo around each silhouette |
+
+Without a sidecar these fall back to `off`.
+
 **4. Convert to WebM** — `src/to_webm.py` *(optional)*
 
 ```bash
@@ -89,6 +205,20 @@ python src/to_webm.py
 ```
 
 Batch-converts all `output/*.mp4` → `output/webm/*.webm` using VP9. Useful for web embedding.
+
+## Source layout
+
+| File | Role |
+|---|---|
+| `pick.py` | interactive ROI + frame-range picker → `rois.json` |
+| `track.py` | background-subtraction tracker |
+| `track_sam3.py` | SAM 3 tracker (CLI, both prompting modes) |
+| `sam3_backend.py` | SAM 3 session wrapper: frame windowing, prompts, masks |
+| `sam3_preflight.py` | environment check for the SAM 3 backend |
+| `trails.py` | shared smoothing, gap fill, palette and tracking-JSON contract |
+| `maskstore.py` | run-length mask sidecar |
+| `render.py` | trail videos |
+| `to_webm.py` | MP4 → WebM |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,23 @@ For the SAM 3 backend only (see [SAM 3 tracking](#sam-3-tracking-track_sam3py)):
 ```bash
 pip install -r requirements-sam3.txt
 git clone https://github.com/facebookresearch/sam3 && pip install -e sam3
-python src/sam3_preflight.py     # verifies python/torch/CUDA/sam3
+python src/sam3_preflight.py     # verifies python/torch/CUDA/sam3/weights
 ```
+
+**Weights.** `track_sam3.py` looks for a local checkpoint in this order:
+
+1. `--checkpoint /path/to/sam3.pt`
+2. `$COMET_SAM3_CHECKPOINT`
+3. `~/ws/models/weights/sam3.pt`, `~/ws/models/weights/sam3.1.pt`,
+   `models/weights/sam3.pt`
+
+A local file is passed straight to the builder as `checkpoint_path`, which
+skips its `load_from_HF` default — so with weights on disk you need no Hugging
+Face account at all. Only if nothing is found does SAM 3 fall back to
+downloading the gated `facebook/sam3` checkpoint, which requires
+[requesting access](https://huggingface.co/facebook/sam3) and
+`huggingface-cli login`. A `--checkpoint` or `$COMET_SAM3_CHECKPOINT` that
+points at a missing file is an error, not a silent fallback to the download.
 
 ## Usage
 
@@ -139,6 +154,8 @@ python src/track_sam3.py --text "drone" --name 0=cf1 --name 1=cf2
 | `--borrow-agents payload --borrow-from <json>` | take that agent from another tracker's output |
 | `--save-masks` | write a `*_masks.npz` sidecar for mask-aware rendering |
 | `--no-gap-fill` | leave dropouts as holes instead of interpolating |
+| `--checkpoint PATH` | weights file (see [Setup](#setup) for the search order) |
+| `--gpus 0,1` | restrict which CUDA devices are used |
 
 **Quality reporting.** Every run logs per-object coverage, longest dropout,
 score range and mask area, and stores them under `sam3_stats` in the tracking

--- a/requirements-sam3.txt
+++ b/requirements-sam3.txt
@@ -1,0 +1,22 @@
+# Optional dependencies for the SAM 3 tracking backend (src/track_sam3.py).
+#
+# The base pipeline (pick.py / track.py / render.py / to_webm.py) does NOT need
+# any of this — install it only on the machine with the GPU.
+#
+# Requirements per the upstream README (https://github.com/facebookresearch/sam3):
+#   Python >= 3.12, PyTorch >= 2.7, CUDA >= 12.6
+#
+# Install:
+#   pip install -r requirements.txt
+#   pip install -r requirements-sam3.txt
+#   git clone https://github.com/facebookresearch/sam3 && pip install -e sam3
+#
+# The SAM 3 checkpoints are gated: request access at
+# https://huggingface.co/facebook/sam3, then `huggingface-cli login`.
+#
+# Verify the whole setup with:
+#   python src/sam3_preflight.py
+
+torch>=2.7
+torchvision
+huggingface_hub

--- a/requirements-sam3.txt
+++ b/requirements-sam3.txt
@@ -11,8 +11,11 @@
 #   pip install -r requirements-sam3.txt
 #   git clone https://github.com/facebookresearch/sam3 && pip install -e sam3
 #
-# The SAM 3 checkpoints are gated: request access at
-# https://huggingface.co/facebook/sam3, then `huggingface-cli login`.
+# Weights: point --checkpoint or $COMET_SAM3_CHECKPOINT at a local sam3.pt (also
+# found automatically at ~/ws/models/weights/sam3.pt).  With a local file no
+# Hugging Face account is needed; without one, SAM 3 downloads the gated
+# facebook/sam3 checkpoint, which needs an access request and
+# `huggingface-cli login` — huggingface_hub below is only for that path.
 #
 # Verify the whole setup with:
 #   python src/sam3_preflight.py

--- a/src/maskstore.py
+++ b/src/maskstore.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# maskstore.py
+"""Run-length mask sidecar for mask-aware rendering.
+
+A 680-frame 1080p run with four objects is ~5.6 GB of raw boolean masks, so
+masks are stored COCO-style: column-major run lengths, alternating background
+and foreground, starting with a background run (possibly of length 0).  For the
+small, compact objects Comet tracks the encoding is a few dozen integers per
+mask, and the whole sidecar stays in the low megabytes.
+
+File layout — a single compressed .npz next to the tracking JSON:
+    meta                     : json blob (height, width, entries index)
+    rle/<frame>/<obj_name>   : int32 run lengths
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def encode_rle(mask: np.ndarray) -> np.ndarray:
+    """Boolean mask → int32 run lengths (column-major, background first)."""
+    flat = np.asarray(mask, dtype=bool).reshape(-1, order="F")
+    if flat.size == 0:
+        return np.zeros(0, dtype=np.int32)
+    # Positions where the value changes, plus the implicit end boundary.
+    change = np.flatnonzero(flat[1:] != flat[:-1]) + 1
+    bounds = np.concatenate(([0], change, [flat.size]))
+    runs = np.diff(bounds)
+    if flat[0]:
+        # Sequence starts with foreground — prepend a zero-length background run
+        # so the alternation is unambiguous at decode time.
+        runs = np.concatenate(([0], runs))
+    return runs.astype(np.int32)
+
+
+def decode_rle(runs: np.ndarray, shape: tuple[int, int]) -> np.ndarray:
+    """Inverse of `encode_rle`."""
+    h, w = shape
+    flat = np.zeros(h * w, dtype=bool)
+    pos = 0
+    for i, run in enumerate(np.asarray(runs).tolist()):
+        if i % 2 == 1 and run:            # odd runs are foreground
+            flat[pos:pos + run] = True
+        pos += run
+    return flat.reshape((h, w), order="F")
+
+
+class MaskStore:
+    """Accumulate masks during tracking, then save; or load them for rendering."""
+
+    def __init__(self, height: int, width: int):
+        self.height = int(height)
+        self.width  = int(width)
+        self._data: dict[str, np.ndarray] = {}
+        self._index: dict[str, list[int]] = {}   # name → frames present
+
+    # -- writing --------------------------------------------------------------
+    def add(self, frame_idx: int, name: str, mask: np.ndarray) -> None:
+        """Store one mask.  Re-adding the same (frame, name) overwrites it —
+        chunked tracking re-emits overlapping frames, and the later pass is the
+        one to keep."""
+        key = f"rle/{int(frame_idx)}/{name}"
+        if key not in self._data:
+            self._index.setdefault(name, []).append(int(frame_idx))
+        self._data[key] = encode_rle(mask)
+
+    def rename(self, mapping: dict[str, str]) -> None:
+        """Re-key stored masks, e.g. from object ids to agent names.
+
+        Text-prompt runs only learn an object's name after propagation, so
+        masks are collected under the id and renamed once naming is settled.
+        """
+        renamed: dict[str, np.ndarray] = {}
+        for key, runs in self._data.items():
+            _, frame, name = key.split("/", 2)
+            renamed[f"rle/{frame}/{mapping.get(name, name)}"] = runs
+        self._data = renamed
+
+        index: dict[str, list[int]] = {}
+        for name, frames in self._index.items():
+            index.setdefault(mapping.get(name, name), []).extend(frames)
+        self._index = {n: sorted(set(f)) for n, f in index.items()}
+
+    def save(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        meta = json.dumps({
+            "height": self.height,
+            "width":  self.width,
+            "index":  {n: sorted(f) for n, f in self._index.items()},
+        })
+        np.savez_compressed(
+            path, meta=np.array(meta), **self._data,
+        )
+        return path
+
+    # -- reading --------------------------------------------------------------
+    @classmethod
+    def load(cls, path: str | Path) -> MaskStore:
+        with np.load(path, allow_pickle=False) as z:
+            meta = json.loads(str(z["meta"]))
+            store = cls(meta["height"], meta["width"])
+            store._index = {n: list(f) for n, f in meta["index"].items()}
+            store._data = {k: z[k] for k in z.files if k.startswith("rle/")}
+        return store
+
+    def get(self, frame_idx: int, name: str) -> np.ndarray | None:
+        runs = self._data.get(f"rle/{int(frame_idx)}/{name}")
+        if runs is None:
+            return None
+        return decode_rle(runs, (self.height, self.width))
+
+    def names(self) -> list[str]:
+        return sorted(self._index)
+
+    def frames(self, name: str) -> list[int]:
+        return list(self._index.get(name, []))
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+def sidecar_path(tracking_json: str | Path) -> Path:
+    """Conventional sidecar location for a tracking JSON."""
+    p = Path(tracking_json)
+    return p.with_name(p.stem.removesuffix("_tracking") + "_masks.npz")

--- a/src/render.py
+++ b/src/render.py
@@ -3,6 +3,7 @@
 Usage:
     python src/render.py                              # uses default data file
     python src/render.py output/crazyflo_path_tracking.json
+    python src/render.py output/crazyflo_sam3_tracking.json --mask-mode occlude
 
 Outputs (MP4, next to the JSON file):
     <stem>_persistent.mp4
@@ -10,16 +11,27 @@ Outputs (MP4, next to the JSON file):
 
 Any trail property can be overridden via the RENDER_* env vars or by editing
 the OVERRIDES dict at the top of this file.
+
+Mask modes (need a *_masks.npz sidecar, written by
+`track_sam3.py --save-masks`; ignored when there is none):
+
+    off       trails drawn straight over the frame, as before
+    occlude   trails pass BEHIND the objects — each object's own pixels are
+              restored on top of the trail canvas
+    glow      occlude, plus a coloured halo around each object's silhouette
 """
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
 
 import cv2
 import numpy as np
-from scipy.signal import savgol_filter
+
+from maskstore import MaskStore, sidecar_path
+from trails import blend_trail, smooth_pts
 
 # ── Optional per-run overrides (None = use value from JSON) ────────────────────
 OVERRIDES: dict = {
@@ -32,28 +44,59 @@ OVERRIDES: dict = {
 
 DEFAULT_DATA_FILE = "output/crazyflo_path_tracking.json"
 
-
-# ── Rendering helpers (mirrors annotate.py) ────────────────────────────────────
-
-def smooth_pts(pts: list) -> list:
-    n = len(pts)
-    if n < 5:
-        return list(pts)
-    win = min(15, n if n % 2 == 1 else n - 1)
-    xs = savgol_filter([p[0] for p in pts], win, 3)
-    ys = savgol_filter([p[1] for p in pts], win, 3)
-    return [(int(x), int(y)) for x, y in zip(xs, ys)]
+GLOW_RADIUS = 9    # px — halo thickness in "glow" mode
+GLOW_ALPHA  = 0.7
 
 
-def blend_trail(frame: np.ndarray, canvas: np.ndarray, alpha: float) -> np.ndarray:
-    mask = canvas.any(axis=2)
-    out  = frame.copy()
-    out[mask] = cv2.addWeighted(frame, 1 - alpha, canvas, alpha, 0)[mask]
+def composite_masks(
+    base: np.ndarray,
+    blended: np.ndarray,
+    masks: dict[str, np.ndarray],
+    color: dict[str, tuple[int, int, int]],
+    mode: str,
+) -> np.ndarray:
+    """Put objects back in front of the trail canvas.
+
+    `blended` already has trails painted over `base`.  Restoring the original
+    pixels wherever an object's mask sits makes the trail read as passing behind
+    the object instead of being smeared across it.
+    """
+    if mode == "off" or not masks:
+        return blended
+
+    out = blended
+    if mode == "glow":
+        halo = np.zeros_like(base)
+        kern = cv2.getStructuringElement(
+            cv2.MORPH_ELLIPSE, (GLOW_RADIUS * 2 + 1, GLOW_RADIUS * 2 + 1))
+        for name, m in masks.items():
+            u = m.astype(np.uint8)
+            ring = cv2.dilate(u, kern) & (1 - u)   # dilated minus the object
+            halo[ring.astype(bool)] = color.get(name, (255, 255, 255))
+        halo = cv2.GaussianBlur(halo, (0, 0), GLOW_RADIUS / 2.0)
+        out = blend_trail(out, halo, GLOW_ALPHA)
+
+    union = np.zeros(base.shape[:2], dtype=bool)
+    for m in masks.values():
+        union |= m
+    out = out.copy()
+    out[union] = base[union]
     return out
 
 
+def load_masks(data_file: str, want: bool) -> MaskStore | None:
+    if not want:
+        return None
+    p = sidecar_path(data_file)
+    if not p.exists():
+        print(f"  no mask sidecar at {p} — falling back to --mask-mode off")
+        return None
+    store = MaskStore.load(p)
+    print(f"  masks: {len(store)} from {p}")
+    return store
 
-def render(data_file: str = DEFAULT_DATA_FILE) -> None:
+
+def render(data_file: str = DEFAULT_DATA_FILE, mask_mode: str = "off") -> None:
     with open(data_file) as f:
         d = json.load(f)
 
@@ -104,6 +147,10 @@ def render(data_file: str = DEFAULT_DATA_FILE) -> None:
     fourcc = cv2.VideoWriter.fourcc(*"mp4v")
     head   = {name: 0 for name in trails}
 
+    store = load_masks(data_file, mask_mode != "off")
+    if store is None:
+        mask_mode = "off"
+
     cap = cv2.VideoCapture(video_in)
     if not cap.isOpened():
         sys.exit(f"Cannot open {video_in}")
@@ -130,6 +177,14 @@ def render(data_file: str = DEFAULT_DATA_FILE) -> None:
                 while head[name] < len(seq) and seq[head[name]][0] <= fi:
                     head[name] += 1
 
+        # Masks for this frame, if a sidecar is loaded.
+        frame_masks: dict[str, np.ndarray] = {}
+        if mask_mode != "off":
+            for name in trails:
+                m = store.get(fi, name)
+                if m is not None and m.shape == (H, W):
+                    frame_masks[name] = m
+
         # ── Persistent ────────────────────────────────────────────────────────
         if show_trail:
             cp = np.zeros((H, W, 3), dtype=np.uint8)
@@ -139,7 +194,9 @@ def render(data_file: str = DEFAULT_DATA_FILE) -> None:
                 if len(draw) >= 2:
                     cv2.polylines(cp, [np.array(draw, dtype=np.int32)],
                                   False, trail_color[name], thickness)
-            wr_p.write(blend_trail(frame, cp, alpha))
+            wr_p.write(composite_masks(
+                frame, blend_trail(frame, cp, alpha),
+                frame_masks, trail_color, mask_mode))
         else:
             wr_p.write(frame)
 
@@ -159,7 +216,9 @@ def render(data_file: str = DEFAULT_DATA_FILE) -> None:
                 col = tuple(int(c * w) for c in trail_color[name])
                 lw  = max(1, round(thickness * w ** 0.5))
                 cv2.line(ct, draw[k], draw[k + 1], col, lw)
-        wr_t.write(blend_trail(frame, ct, alpha))
+        wr_t.write(composite_masks(
+            frame, blend_trail(frame, ct, alpha),
+            frame_masks, trail_color, mask_mode))
 
         if fi % 30 == 0:
             sys.stdout.write(f"\r  {100*fi/total:.0f}%")
@@ -174,5 +233,17 @@ def render(data_file: str = DEFAULT_DATA_FILE) -> None:
     print(f"Done.\n  {out_p}\n  {out_t}")
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("data_file", nargs="?", default=DEFAULT_DATA_FILE)
+    p.add_argument("--mask-mode", choices=("off", "occlude", "glow"), default="off",
+                   help="use the *_masks.npz sidecar to composite objects over "
+                        "the trails (default: off)")
+    return p.parse_args(argv)
+
+
 if __name__ == "__main__":
-    render(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DATA_FILE)
+    _a = parse_args()
+    render(_a.data_file, _a.mask_mode)

--- a/src/sam3_backend.py
+++ b/src/sam3_backend.py
@@ -1,0 +1,926 @@
+#!/usr/bin/env python3
+# sam3_backend.py
+"""SAM 3 video-tracking backend for Comet.
+
+Wraps Meta's `Sam3VideoPredictor` session API and reduces its per-frame mask
+output to the (frame_index → point) form the Comet render pipeline consumes.
+
+────────────────────────────────────────────────────────────────────────────────
+API ASSUMPTIONS
+────────────────────────────────────────────────────────────────────────────────
+Everything this module assumes about the upstream SAM 3 package is collected in
+`_ADAPTER` below and in `normalize_frame_outputs()`.  The session verbs
+(`start_session` / `add_prompt` / `propagate_in_video` / `close_session`) and
+the text- and point-prompt payloads are taken from the official example
+notebook:
+
+    https://github.com/facebookresearch/sam3/blob/main/examples/
+        sam3_video_predictor_example.ipynb
+
+Two things that notebook does NOT pin down, and which this module therefore
+probes at runtime rather than hard-codes:
+
+  * the keyword for a BOX prompt — tried in order from `BOX_PROMPT_KEYS`;
+  * the exact shape of `response["outputs"]` — `normalize_frame_outputs()`
+    accepts every plausible layout and raises a loud, descriptive error if it
+    meets one it does not recognise.
+
+If upstream changes, fix it here; nothing else in the repo touches SAM 3.
+
+Nothing in this module imports torch or sam3 at module scope, so the rest of
+the pipeline (and the test suite) still runs on a machine without them.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+# ── Adapter constants ──────────────────────────────────────────────────────────
+
+# Candidate keyword names for a box prompt, tried in order until one is accepted.
+BOX_PROMPT_KEYS: tuple[str, ...] = ("box", "boxes", "bbox", "input_boxes")
+
+# Keys searched when pulling masks / ids / scores out of a frame's outputs.
+_MASK_KEYS  = ("pred_masks", "masks", "mask", "pred_mask", "masklets")
+_ID_KEYS    = ("obj_ids", "object_ids", "obj_id", "ids", "objects")
+_SCORE_KEYS = ("scores", "score", "obj_scores", "pred_scores", "confidences")
+
+_ADAPTER = {
+    "start":     "start_session",
+    "prompt":    "add_prompt",
+    "propagate": "propagate_in_video",
+    "reset":     "reset_session",
+    "close":     "close_session",
+    "remove":    "remove_object",
+}
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+
+@dataclass
+class Sam3Config:
+    """Knobs for a SAM 3 tracking run."""
+
+    # Prompting
+    normalize_coords: bool = False   # send box/point coords as 0-1 instead of px
+    box_key: str | None    = None    # force a box-prompt keyword; None = probe
+
+    # Mask → point reduction
+    point_mode: str = "centroid"     # "centroid" (mask barycentre) or "bbox"
+    mask_threshold: float = 0.0      # logit threshold; probabilities use 0.5
+
+    # Filtering
+    min_score: float = 0.0           # drop observations below this score
+    min_area: int    = 1             # drop masks smaller than this many px
+
+    # Long-video handling
+    chunk_size: int = 0              # 0 = single pass over the whole window
+    chunk_overlap: int = 8           # frames of context re-prompted per chunk
+
+    # Runtime
+    gpus: list[int] | None = None    # None = every visible CUDA device
+    keep_masks: bool = False         # decode full masks at all
+    # Called as sink(absolute_frame, obj_id, mask) for every mask, which is then
+    # dropped from the Observation.  Masks are big — a 1080p boolean mask is
+    # ~2 MB, so a 680-frame run with four objects would be ~5 GB if they were
+    # all held in memory.  The sink lets the caller compress as they arrive.
+    mask_sink: object | None = None
+    extra_builder_kwargs: dict = field(default_factory=dict)
+
+
+# ── Frame window ───────────────────────────────────────────────────────────────
+
+class FrameWindow:
+    """A [start_frame, end_frame] slice of a video, extracted as JPEG frames.
+
+    SAM 3 indexes the frames it is given from 0.  Comet's tracking JSON is keyed
+    by ABSOLUTE frame index in the source video, because render.py walks the
+    original footage.  This class owns that mapping — every index crossing the
+    boundary goes through `to_absolute` / `to_local` and nowhere else.
+    """
+
+    def __init__(self, video: str, start_frame: int, end_frame: int | None):
+        self.video       = video
+        self.start_frame = int(start_frame)
+        self.end_frame   = end_frame
+        self.dir: Path | None = None
+        self._tmp: str | None = None
+        self.n_frames = 0
+        self.width    = 0
+        self.height   = 0
+        self.fps      = 30.0
+        self.total_frames = 0
+
+    # -- index mapping --------------------------------------------------------
+    def to_absolute(self, local_idx: int) -> int:
+        return self.start_frame + int(local_idx)
+
+    def to_local(self, abs_idx: int) -> int:
+        return int(abs_idx) - self.start_frame
+
+    # -- extraction -----------------------------------------------------------
+    def extract(self, dest: str | Path | None = None, quality: int = 95) -> Path:
+        """Write the window's frames as zero-padded JPEGs and return the dir."""
+        cap = cv2.VideoCapture(self.video)
+        if not cap.isOpened():
+            raise RuntimeError(f"Cannot open video: {self.video}")
+
+        self.fps          = cap.get(cv2.CAP_PROP_FPS) or 30.0
+        self.width        = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        self.height       = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        self.total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+        last = self.end_frame if self.end_frame is not None else self.total_frames - 1
+        last = min(last, self.total_frames - 1)
+        if last < self.start_frame:
+            cap.release()
+            raise ValueError(
+                f"Empty frame window: start_frame={self.start_frame} > end_frame={last}"
+            )
+
+        if dest is None:
+            self._tmp = tempfile.mkdtemp(prefix="comet_sam3_frames_")
+            out_dir = Path(self._tmp)
+        else:
+            out_dir = Path(dest)
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Advance by grabbing rather than setting CAP_PROP_POS_FRAMES.  That
+        # property's frame accuracy depends on the container and codec, while
+        # sequential decode is exact for all of them — and it has to be exact,
+        # because render.py reads the source from frame 0 sequentially, so any
+        # discrepancy offsets every trail against the footage.  grab() skips the
+        # decode of the frames we discard, so the scan stays cheap.
+        for _ in range(self.start_frame):
+            if not cap.grab():
+                cap.release()
+                raise ValueError(
+                    f"Video has fewer than start_frame={self.start_frame} frames"
+                )
+
+        written = 0
+        for abs_idx in range(self.start_frame, last + 1):
+            ok, frame = cap.read()
+            if not ok:
+                logging.warning(
+                    f"Video ended early at frame {abs_idx} (expected through {last})"
+                )
+                break
+            cv2.imwrite(
+                str(out_dir / f"{written:06d}.jpg"), frame,
+                [int(cv2.IMWRITE_JPEG_QUALITY), quality],
+            )
+            written += 1
+        cap.release()
+
+        if written == 0:
+            raise RuntimeError(f"No frames extracted from {self.video}")
+
+        self.n_frames = written
+        self.dir = out_dir
+        logging.info(
+            f"Extracted {written} frames "
+            f"({self.start_frame}→{self.to_absolute(written - 1)}) → {out_dir}"
+        )
+        return out_dir
+
+    def read_frame(self, abs_idx: int) -> np.ndarray | None:
+        """Read one extracted frame by absolute index (for debug rendering)."""
+        if self.dir is None:
+            return None
+        p = self.dir / f"{self.to_local(abs_idx):06d}.jpg"
+        if not p.exists():
+            return None
+        return cv2.imread(str(p))
+
+    def cleanup(self) -> None:
+        if self._tmp:
+            shutil.rmtree(self._tmp, ignore_errors=True)
+            self._tmp = None
+            self.dir  = None
+
+    def __enter__(self) -> FrameWindow:
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.cleanup()
+
+
+# ── Observations ───────────────────────────────────────────────────────────────
+
+@dataclass
+class Observation:
+    """One object, on one frame."""
+    obj_id: int
+    cx: int
+    cy: int
+    bbox: tuple[int, int, int, int]
+    area: int
+    score: float
+    mask: np.ndarray | None = None   # bool HxW, only when keep_masks
+
+
+def _as_tensor(data, dtype: str):
+    """Build a float32/int32 tensor, falling back to numpy when torch is absent.
+
+    Real runs always have torch — the predictor wants tensors.  The fallback
+    exists so this module stays importable, and the prompt paths stay testable,
+    on a machine with no GPU stack installed.
+    """
+    try:
+        import torch
+    except ImportError:
+        return np.asarray(data, dtype=np.float32 if dtype == "float32" else np.int32)
+    return torch.tensor(
+        data, dtype=torch.float32 if dtype == "float32" else torch.int32,
+    )
+
+
+def _to_numpy(x):
+    """Duck-typed tensor → ndarray, so this module never imports torch."""
+    if x is None:
+        return None
+    if isinstance(x, np.ndarray):
+        return x
+    for attr in ("detach", "cpu", "numpy"):
+        if hasattr(x, attr):
+            break
+    else:
+        return np.asarray(x)
+    if hasattr(x, "detach"):
+        x = x.detach()
+    if hasattr(x, "cpu"):
+        x = x.cpu()
+    if hasattr(x, "numpy"):
+        return x.numpy()
+    return np.asarray(x)
+
+
+def binarize_mask(raw, threshold: float = 0.0) -> np.ndarray:
+    """Coerce a SAM mask of unknown dtype/shape into a 2-D bool array.
+
+    SAM decoders emit logits (any real value, positive = foreground); some
+    wrappers pre-apply a sigmoid, and some return bools already.  Guessing wrong
+    turns a whole frame into foreground, so the three cases are separated
+    explicitly rather than thresholded uniformly.
+    """
+    m = _to_numpy(raw)
+    if m is None:
+        raise ValueError("mask is None")
+    m = np.squeeze(m)
+    if m.ndim > 2:
+        # e.g. [1, H, W] leftovers or a multi-hypothesis axis — take the first.
+        m = m.reshape(-1, *m.shape[-2:])[0]
+    if m.ndim != 2:
+        raise ValueError(f"Cannot reduce mask of shape {np.shape(raw)} to 2-D")
+
+    if m.dtype == np.bool_:
+        return m
+    if np.issubdtype(m.dtype, np.integer):
+        return m > 0
+    lo, hi = float(np.min(m)), float(np.max(m))
+    if lo >= 0.0 and hi <= 1.0:
+        return m >= 0.5          # probabilities
+    return m > threshold         # logits
+
+
+def mask_to_observation(
+    mask: np.ndarray,
+    obj_id: int,
+    score: float,
+    point_mode: str = "centroid",
+    keep_mask: bool = False,
+) -> Observation | None:
+    """Reduce a boolean mask to a trail point + bbox.  None if the mask is empty."""
+    ys, xs = np.nonzero(mask)
+    if xs.size == 0:
+        return None
+    x0, x1 = int(xs.min()), int(xs.max())
+    y0, y1 = int(ys.min()), int(ys.max())
+    bbox = (x0, y0, x1 - x0 + 1, y1 - y0 + 1)
+
+    if point_mode == "bbox":
+        cx = x0 + bbox[2] // 2
+        cy = y0 + bbox[3] // 2
+    else:
+        # Mask barycentre: steadier than the bbox centre when an object is
+        # partially occluded, since a clipped edge shifts the box but only
+        # reweights the centroid.
+        cx = int(round(float(xs.mean())))
+        cy = int(round(float(ys.mean())))
+
+    return Observation(
+        obj_id = int(obj_id),
+        cx     = cx,
+        cy     = cy,
+        bbox   = bbox,
+        area   = int(xs.size),
+        score  = float(score),
+        mask   = mask if keep_mask else None,
+    )
+
+
+def _first_key(d: dict, keys: tuple[str, ...]):
+    for k in keys:
+        if k in d:
+            return d[k]
+    return None
+
+
+def normalize_frame_outputs(
+    outputs,
+    frame_shape: tuple[int, int],
+    cfg: Sam3Config,
+) -> dict[int, Observation]:
+    """Turn one frame's `response["outputs"]` into {obj_id: Observation}.
+
+    Accepts the layouts SAM 3 / SAM 2 wrappers are known to emit:
+      * {"pred_masks": [N,1,H,W], "obj_ids": [...], "scores": [...]}
+      * {"masks": ..., "object_ids": ...}
+      * {obj_id: mask}
+      * {obj_id: {"mask": ..., "score": ...}}
+      * an object exposing any of the above as attributes
+    """
+    H, W = frame_shape
+    if outputs is None:
+        return {}
+
+    # Attribute-style container → dict of its interesting attributes.
+    if not isinstance(outputs, dict):
+        collected = {
+            k: getattr(outputs, k)
+            for k in (*_MASK_KEYS, *_ID_KEYS, *_SCORE_KEYS)
+            if hasattr(outputs, k)
+        }
+        if not collected:
+            raise TypeError(
+                f"Unrecognised SAM 3 frame output of type {type(outputs)!r}; "
+                f"extend normalize_frame_outputs() in sam3_backend.py"
+            )
+        outputs = collected
+
+    masks  = _first_key(outputs, _MASK_KEYS)
+    ids    = _first_key(outputs, _ID_KEYS)
+    scores = _first_key(outputs, _SCORE_KEYS)
+
+    pairs: list[tuple[int, object, float]] = []
+
+    if masks is not None:
+        arr = _to_numpy(masks)
+        if arr is None:
+            return {}
+        # Collapse a singleton channel axis: [N,1,H,W] → [N,H,W]
+        if arr.ndim == 4 and arr.shape[1] == 1:
+            arr = arr[:, 0]
+        if arr.ndim == 2:                 # single unbatched mask
+            arr = arr[None]
+        if ids is None:
+            ids = list(range(len(arr)))
+        ids = [int(i) for i in _to_numpy(ids).tolist()] if not isinstance(ids, list) \
+            else [int(i) for i in ids]
+        if scores is None:
+            score_list = [1.0] * len(arr)
+        else:
+            s = _to_numpy(scores)
+            score_list = [float(v) for v in np.asarray(s).reshape(-1).tolist()]
+            score_list += [1.0] * (len(arr) - len(score_list))
+        if len(ids) != len(arr):
+            raise ValueError(
+                f"SAM 3 returned {len(arr)} masks but {len(ids)} object ids"
+            )
+        pairs = list(zip(ids, list(arr), score_list))
+    else:
+        # Mapping form: {obj_id: mask} or {obj_id: {"mask":..., "score":...}}
+        for k, v in outputs.items():
+            try:
+                oid = int(k)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(v, dict):
+                m = _first_key(v, _MASK_KEYS)
+                s = _first_key(v, _SCORE_KEYS)
+                pairs.append((oid, m, float(s) if s is not None else 1.0))
+            else:
+                pairs.append((oid, v, 1.0))
+        if not pairs:
+            raise TypeError(
+                f"No masks found in SAM 3 frame output with keys {list(outputs)}; "
+                f"extend normalize_frame_outputs() in sam3_backend.py"
+            )
+
+    obs: dict[int, Observation] = {}
+    for oid, raw_mask, score in pairs:
+        if raw_mask is None:
+            continue
+        mask = binarize_mask(raw_mask, cfg.mask_threshold)
+        if mask.shape != (H, W):
+            # SAM works at its own resolution; nearest-neighbour keeps it binary.
+            mask = cv2.resize(
+                mask.astype(np.uint8), (W, H), interpolation=cv2.INTER_NEAREST
+            ).astype(bool)
+        o = mask_to_observation(mask, oid, score, cfg.point_mode, cfg.keep_masks)
+        if o is None or o.area < cfg.min_area or o.score < cfg.min_score:
+            continue
+        obs[o.obj_id] = o
+    return obs
+
+
+# ── Predictor session ──────────────────────────────────────────────────────────
+
+class Sam3Session:
+    """Context manager around one SAM 3 video session."""
+
+    def __init__(self, predictor, resource_path: str | Path, cfg: Sam3Config):
+        self.predictor = predictor
+        self.resource_path = str(resource_path)
+        self.cfg = cfg
+        self.session_id = None
+        self._box_key: str | None = cfg.box_key
+
+    # -- lifecycle ------------------------------------------------------------
+    def __enter__(self) -> Sam3Session:
+        resp = self.predictor.handle_request(request=dict(
+            type=_ADAPTER["start"], resource_path=self.resource_path,
+        ))
+        self.session_id = resp["session_id"]
+        logging.info(f"SAM 3 session {self.session_id} on {self.resource_path}")
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self.session_id is not None:
+            try:
+                self.predictor.handle_request(request=dict(
+                    type=_ADAPTER["close"], session_id=self.session_id,
+                ))
+            except Exception as e:              # noqa: BLE001 - cleanup only
+                logging.warning(f"close_session failed: {e}")
+            self.session_id = None
+
+    def reset(self) -> None:
+        """Clear all prompts.  Required before re-prompting the same session."""
+        self.predictor.handle_request(request=dict(
+            type=_ADAPTER["reset"], session_id=self.session_id,
+        ))
+
+    # -- prompts --------------------------------------------------------------
+    def _scale(self, xs: list[float], ys: list[float], w: int, h: int):
+        if not self.cfg.normalize_coords:
+            return xs, ys
+        return [x / w for x in xs], [y / h for y in ys]
+
+    def add_text_prompt(self, text: str, frame_index: int = 0) -> dict:
+        resp = self.predictor.handle_request(request=dict(
+            type=_ADAPTER["prompt"], session_id=self.session_id,
+            frame_index=int(frame_index), text=text,
+        ))
+        return resp.get("outputs")
+
+    def add_point_prompt(
+        self, points: list[tuple[float, float]], labels: list[int],
+        obj_id: int, frame_index: int, frame_size: tuple[int, int],
+    ) -> dict:
+        h, w = frame_size
+        xs, ys = self._scale([p[0] for p in points], [p[1] for p in points], w, h)
+        pts = _as_tensor(list(zip(xs, ys)), "float32")
+        lbl = _as_tensor(labels, "int32")
+        resp = self.predictor.handle_request(request=dict(
+            type=_ADAPTER["prompt"], session_id=self.session_id,
+            frame_index=int(frame_index), points=pts, point_labels=lbl,
+            obj_id=int(obj_id),
+        ))
+        return resp.get("outputs")
+
+    def add_box_prompt(
+        self, box_xywh: tuple[float, float, float, float],
+        obj_id: int, frame_index: int, frame_size: tuple[int, int],
+    ) -> dict:
+        """Add an (x, y, w, h) box prompt, probing for the accepted keyword.
+
+        The upstream example notebook only documents point and text prompts, so
+        the box keyword is discovered on first use and then reused.
+        """
+        h, w = frame_size
+        x, y, bw, bh = box_xywh
+        xs, ys = self._scale([x, x + bw], [y, y + bh], w, h)
+        box = _as_tensor([[xs[0], ys[0], xs[1], ys[1]]], "float32")   # xyxy
+
+        keys = (self._box_key,) if self._box_key else BOX_PROMPT_KEYS
+        errors: list[str] = []
+        for key in keys:
+            req = dict(
+                type=_ADAPTER["prompt"], session_id=self.session_id,
+                frame_index=int(frame_index), obj_id=int(obj_id),
+            )
+            req[key] = box
+            try:
+                resp = self.predictor.handle_request(request=req)
+            except Exception as e:              # noqa: BLE001 - probing
+                errors.append(f"{key}: {type(e).__name__}: {e}")
+                continue
+            if self._box_key != key:
+                self._box_key = key
+                logging.info(f"SAM 3 box prompts use keyword '{key}'")
+            return resp.get("outputs")
+
+        raise RuntimeError(
+            "No accepted box-prompt keyword. Tried "
+            f"{list(keys)}. Pass --box-key, or fall back to --prompt-shape point.\n"
+            + "\n".join(errors)
+        )
+
+    # -- propagation ----------------------------------------------------------
+    def propagate(self):
+        """Yield (local_frame_index, raw_outputs) for every frame."""
+        for response in self.predictor.handle_stream_request(request=dict(
+            type=_ADAPTER["propagate"], session_id=self.session_id,
+        )):
+            yield int(response["frame_index"]), response.get("outputs")
+
+
+def build_predictor(cfg: Sam3Config):
+    """Import and construct the upstream predictor.  Fails loudly and usefully."""
+    try:
+        import torch
+        from sam3.model_builder import build_sam3_video_predictor
+    except ImportError as e:
+        raise ImportError(
+            f"SAM 3 is not installed in this environment ({e}). "
+            "See requirements-sam3.txt and run `python src/sam3_preflight.py`."
+        ) from e
+
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "SAM 3 video tracking needs a CUDA GPU; torch.cuda.is_available() is "
+            "False. Run `python src/sam3_preflight.py` for details."
+        )
+
+    gpus = cfg.gpus if cfg.gpus is not None else list(range(torch.cuda.device_count()))
+    logging.info(f"Building SAM 3 video predictor on GPUs {gpus}")
+    return build_sam3_video_predictor(gpus_to_use=gpus, **cfg.extra_builder_kwargs)
+
+
+# ── Orchestration ──────────────────────────────────────────────────────────────
+
+@dataclass
+class PromptSpec:
+    """One thing to track: a name, and how to seed it on the first frame."""
+    name: str
+    obj_id: int
+    box: tuple[float, float, float, float] | None = None   # (x, y, w, h)
+    point: tuple[float, float] | None = None
+
+
+def track_window(
+    window: FrameWindow,
+    cfg: Sam3Config,
+    *,
+    predictor=None,
+    text: str | None = None,
+    prompts: list[PromptSpec] | None = None,
+    prompt_shape: str = "box",
+    progress: bool = True,
+) -> dict[int, dict[int, Observation]]:
+    """Run SAM 3 over `window` and return {absolute_frame: {obj_id: Observation}}.
+
+    Exactly one of `text` (concept prompt, objects discovered by the detector)
+    or `prompts` (one seeded object per spec, identities fixed by the caller)
+    must be given.
+    """
+    if (text is None) == (prompts is None):
+        raise ValueError("Pass exactly one of text= or prompts=")
+    if window.dir is None:
+        raise RuntimeError("Call FrameWindow.extract() before track_window()")
+
+    own_predictor = predictor is None
+    predictor = predictor or build_predictor(cfg)
+    frame_size = (window.height, window.width)
+
+    results: dict[int, dict[int, Observation]] = {}
+    try:
+        with Sam3Session(predictor, window.dir, cfg) as sess:
+            if text is not None:
+                sess.add_text_prompt(text, frame_index=0)
+                logging.info(f"Text prompt {text!r} on local frame 0")
+            else:
+                for spec in prompts:
+                    if prompt_shape == "point" or spec.box is None:
+                        pt = spec.point
+                        if pt is None and spec.box is not None:
+                            x, y, w, h = spec.box
+                            pt = (x + w / 2, y + h / 2)
+                        if pt is None:
+                            raise ValueError(f"{spec.name}: no box and no point")
+                        sess.add_point_prompt([pt], [1], spec.obj_id, 0, frame_size)
+                    else:
+                        sess.add_box_prompt(spec.box, spec.obj_id, 0, frame_size)
+                    logging.info(
+                        f"Seeded {spec.name} as obj_id={spec.obj_id} "
+                        f"({'point' if prompt_shape == 'point' else 'box'})"
+                    )
+
+            for local_idx, raw in sess.propagate():
+                abs_idx = window.to_absolute(local_idx)
+                per_obj = normalize_frame_outputs(raw, frame_size, cfg)
+                if cfg.mask_sink is not None:
+                    for oid, obs in per_obj.items():
+                        if obs.mask is not None:
+                            cfg.mask_sink(abs_idx, oid, obs.mask)
+                            obs.mask = None      # freed as soon as it is stored
+                results[abs_idx] = per_obj
+                if progress and local_idx % 30 == 0 and window.n_frames:
+                    pct = 100 * (local_idx + 1) / window.n_frames
+                    print(f"\r  sam3 propagating {pct:.0f}%", end="", flush=True)
+        if progress:
+            print("\r  sam3 propagating 100%")
+    finally:
+        if own_predictor and hasattr(predictor, "shutdown"):
+            try:
+                predictor.shutdown()
+            except Exception as e:              # noqa: BLE001 - cleanup only
+                logging.warning(f"predictor.shutdown() failed: {e}")
+
+    return results
+
+
+def _make_chunk_dir(window: FrameWindow, root: Path, lo: int, hi: int) -> Path:
+    """Symlink local frames [lo, hi) into their own directory, renumbered from 0.
+
+    SAM 3 takes a directory of frames as its resource, so a chunk is just a
+    cheap alternate view of the frames already on disk — no re-encoding.
+    """
+    d = root / f"chunk_{lo:06d}"
+    d.mkdir(parents=True, exist_ok=True)
+    for k, local in enumerate(range(lo, hi)):
+        src = window.dir / f"{local:06d}.jpg"
+        dst = d / f"{k:06d}.jpg"
+        if dst.exists() or dst.is_symlink():
+            dst.unlink()
+        try:
+            dst.symlink_to(src.resolve())
+        except OSError:
+            shutil.copy2(src, dst)   # filesystems without symlink support
+    return d
+
+
+def track_window_chunked(
+    window: FrameWindow,
+    cfg: Sam3Config,
+    *,
+    predictor=None,
+    text: str | None = None,
+    prompts: list[PromptSpec] | None = None,
+    prompt_shape: str = "box",
+) -> dict[int, dict[int, Observation]]:
+    """Propagate in fixed-length chunks, re-seeding each chunk from the last one.
+
+    Serves two purposes: it bounds the memory bank's VRAM growth on long clips,
+    and it re-anchors identities periodically so a single bad frame cannot
+    poison the rest of the run.  Object ids stay stable across chunks because
+    every chunk after the first is seeded with explicit obj_ids taken from the
+    previous chunk's final masks.
+    """
+    if cfg.chunk_size <= 0:
+        return track_window(window, cfg, predictor=predictor, text=text,
+                            prompts=prompts, prompt_shape=prompt_shape)
+    if window.dir is None:
+        raise RuntimeError("Call FrameWindow.extract() before track_window_chunked()")
+
+    own_predictor = predictor is None
+    predictor = predictor or build_predictor(cfg)
+    # Overlap must leave the window advancing: at chunk_overlap >= chunk_size a
+    # chunk would start at or before the previous one and the loop never ends.
+    overlap = max(0, min(cfg.chunk_overlap, cfg.chunk_size - 1))
+    if overlap != cfg.chunk_overlap:
+        logging.warning(
+            f"chunk_overlap {cfg.chunk_overlap} >= chunk_size {cfg.chunk_size}; "
+            f"clamped to {overlap}"
+        )
+    root = Path(tempfile.mkdtemp(prefix="comet_sam3_chunks_"))
+
+    merged: dict[int, dict[int, Observation]] = {}
+    try:
+        lo = 0
+        chunk_no = 0
+        carry: list[PromptSpec] | None = None
+        while lo < window.n_frames:
+            hi = min(window.n_frames, lo + cfg.chunk_size)
+            chunk_dir = _make_chunk_dir(window, root, lo, hi)
+            sub = FrameWindow(window.video, window.to_absolute(lo), None)
+            sub.dir      = chunk_dir
+            sub.n_frames = hi - lo
+            sub.width, sub.height = window.width, window.height
+
+            if chunk_no == 0:
+                out = track_window(sub, cfg, predictor=predictor, text=text,
+                                   prompts=prompts, prompt_shape=prompt_shape,
+                                   progress=False)
+            else:
+                if not carry:
+                    logging.warning(
+                        f"Chunk {chunk_no}: nothing to re-seed with — "
+                        f"tracking stops at frame {window.to_absolute(lo)}"
+                    )
+                    break
+                out = track_window(sub, cfg, predictor=predictor, prompts=carry,
+                                   prompt_shape="box", progress=False)
+
+            # Later chunks win on overlapping frames: they carry fresher context.
+            merged.update(out)
+
+            # Seed the next chunk from the most recent frame that saw anything.
+            carry = None
+            for abs_idx in sorted(out, reverse=True):
+                if out[abs_idx]:
+                    carry = [
+                        PromptSpec(name=str(oid), obj_id=oid, box=obs.bbox)
+                        for oid, obs in sorted(out[abs_idx].items())
+                    ]
+                    break
+
+            print(f"\r  sam3 propagating {100 * hi / window.n_frames:.0f}%",
+                  end="", flush=True)
+            nxt = hi - overlap if hi < window.n_frames else hi
+            if nxt <= lo:                    # belt and braces: never stall
+                raise RuntimeError(
+                    f"Chunk window did not advance (lo={lo}, next={nxt}, "
+                    f"chunk_size={cfg.chunk_size}, overlap={overlap})"
+                )
+            lo = nxt
+            chunk_no += 1
+        print("\r  sam3 propagating 100%")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        if own_predictor and hasattr(predictor, "shutdown"):
+            try:
+                predictor.shutdown()
+            except Exception as e:              # noqa: BLE001 - cleanup only
+                logging.warning(f"predictor.shutdown() failed: {e}")
+
+    return merged
+
+
+# ── Zoom-crop tracking for tiny objects ────────────────────────────────────────
+
+def track_object_zoom(
+    window: FrameWindow,
+    cfg: Sam3Config,
+    seed_box: tuple[float, float, float, float],
+    obj_id: int,
+    *,
+    predictor=None,
+    crop_size: int = 384,
+    upscale: int = 3,
+    segment_len: int = 60,
+) -> dict[int, Observation]:
+    """Track one small object by following it through an upscaled crop.
+
+    A 26x34 px payload is ~0.04 % of a 1080p frame; after SAM's internal
+    downscaling there is very little signal left.  Cropping a `crop_size` window
+    around the object and upscaling it by `upscale` puts the object back into
+    the size range the model handles well.
+
+    The crop is re-centred every `segment_len` frames from the object's own last
+    position, which bounds how far it can drift towards the crop edge.  If the
+    object is lost in a segment, tracking stops there rather than silently
+    following whatever else is in frame.
+
+    Returns {absolute_frame: Observation} in FULL-FRAME coordinates.
+    """
+    if window.dir is None:
+        raise RuntimeError("Call FrameWindow.extract() before track_object_zoom()")
+
+    own_predictor = predictor is None
+    predictor = predictor or build_predictor(cfg)
+    half = crop_size // 2
+    out: dict[int, Observation] = {}
+    root = Path(tempfile.mkdtemp(prefix="comet_sam3_zoom_"))
+
+    # Crop config mirrors the caller's, but masks live in crop space and are
+    # translated back below, so never keep them at crop resolution.
+    crop_cfg = Sam3Config(
+        normalize_coords=cfg.normalize_coords, box_key=cfg.box_key,
+        point_mode=cfg.point_mode, mask_threshold=cfg.mask_threshold,
+        min_score=cfg.min_score, min_area=1, keep_masks=False,
+    )
+
+    try:
+        cx = seed_box[0] + seed_box[2] / 2
+        cy = seed_box[1] + seed_box[3] / 2
+        cur_box = seed_box
+        lo = 0
+        while lo < window.n_frames:
+            hi = min(window.n_frames, lo + segment_len)
+
+            # Clamp the crop so it stays inside the frame.
+            x0 = int(max(0, min(window.width  - crop_size, cx - half)))
+            y0 = int(max(0, min(window.height - crop_size, cy - half)))
+            cw = min(crop_size, window.width  - x0)
+            ch = min(crop_size, window.height - y0)
+
+            seg_dir = root / f"zoom_{lo:06d}"
+            seg_dir.mkdir(parents=True, exist_ok=True)
+            for k, local in enumerate(range(lo, hi)):
+                img = cv2.imread(str(window.dir / f"{local:06d}.jpg"))
+                if img is None:
+                    break
+                crop = img[y0:y0 + ch, x0:x0 + cw]
+                crop = cv2.resize(crop, (cw * upscale, ch * upscale),
+                                  interpolation=cv2.INTER_CUBIC)
+                cv2.imwrite(str(seg_dir / f"{k:06d}.jpg"), crop)
+
+            seg = FrameWindow(window.video, window.to_absolute(lo), None)
+            seg.dir      = seg_dir
+            seg.n_frames = hi - lo
+            seg.width, seg.height = cw * upscale, ch * upscale
+
+            # Seed box expressed in upscaled-crop coordinates.
+            sb = ((cur_box[0] - x0) * upscale, (cur_box[1] - y0) * upscale,
+                  max(1.0, cur_box[2] * upscale), max(1.0, cur_box[3] * upscale))
+            seg_res = track_window(
+                seg, crop_cfg, predictor=predictor,
+                prompts=[PromptSpec(name="zoom", obj_id=obj_id, box=sb)],
+                progress=False,
+            )
+
+            last_seen = None
+            for abs_idx in sorted(seg_res):
+                obs = seg_res[abs_idx].get(obj_id)
+                if obs is None:
+                    continue
+                # Crop space → full-frame space.
+                fx = x0 + obs.bbox[0] / upscale
+                fy = y0 + obs.bbox[1] / upscale
+                fw = max(1.0, obs.bbox[2] / upscale)
+                fh = max(1.0, obs.bbox[3] / upscale)
+                out[abs_idx] = Observation(
+                    obj_id = obj_id,
+                    cx     = int(round(x0 + obs.cx / upscale)),
+                    cy     = int(round(y0 + obs.cy / upscale)),
+                    bbox   = (int(fx), int(fy), int(round(fw)), int(round(fh))),
+                    area   = max(1, int(obs.area / (upscale ** 2))),
+                    score  = obs.score,
+                )
+                last_seen = out[abs_idx]
+
+            if last_seen is None:
+                logging.warning(
+                    f"Zoom track lost the object in frames "
+                    f"{window.to_absolute(lo)}→{window.to_absolute(hi - 1)}; stopping"
+                )
+                break
+            cx, cy   = last_seen.cx, last_seen.cy
+            cur_box  = last_seen.bbox
+            shutil.rmtree(seg_dir, ignore_errors=True)
+            lo = hi
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        if own_predictor and hasattr(predictor, "shutdown"):
+            try:
+                predictor.shutdown()
+            except Exception as e:              # noqa: BLE001 - cleanup only
+                logging.warning(f"predictor.shutdown() failed: {e}")
+
+    return out
+
+
+def observations_to_trails(
+    results: dict[int, dict[int, Observation]],
+    id_to_name: dict[int, str],
+) -> dict[str, dict[int, tuple[int, int]]]:
+    """Reduce per-frame observations to the {name: {frame: (cx, cy)}} trail form."""
+    trails: dict[str, dict[int, tuple[int, int]]] = {n: {} for n in id_to_name.values()}
+    for abs_idx, per_obj in results.items():
+        for oid, obs in per_obj.items():
+            name = id_to_name.get(oid)
+            if name is None:
+                continue
+            trails[name][abs_idx] = (obs.cx, obs.cy)
+    return trails
+
+
+def discover_id_names(
+    results: dict[int, dict[int, Observation]],
+    prefix: str = "obj",
+    name_map: dict[int, str] | None = None,
+) -> dict[int, str]:
+    """Name every object id seen during a text-prompt run.
+
+    Ids are ordered by first appearance so the naming is stable across reruns
+    of the same clip, rather than following the detector's internal ordering.
+    """
+    seen: list[int] = []
+    for abs_idx in sorted(results):
+        for oid in sorted(results[abs_idx]):
+            if oid not in seen:
+                seen.append(oid)
+    out = {}
+    for rank, oid in enumerate(seen):
+        out[oid] = (name_map or {}).get(oid, f"{prefix}{rank}")
+    return out

--- a/src/sam3_backend.py
+++ b/src/sam3_backend.py
@@ -33,6 +33,7 @@ the pipeline (and the test suite) still runs on a machine without them.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import tempfile
 from dataclasses import dataclass, field
@@ -46,6 +47,47 @@ import numpy as np
 
 # Candidate keyword names for a box prompt, tried in order until one is accepted.
 BOX_PROMPT_KEYS: tuple[str, ...] = ("box", "boxes", "bbox", "input_boxes")
+
+# Where to look for a local SAM 3 checkpoint, in order.  Upstream's builder
+# defaults to `load_from_HF=True`, which downloads the gated facebook/sam3
+# checkpoint; passing `checkpoint_path` skips that entirely, so a local weights
+# file means no Hugging Face account or access request is needed.
+CHECKPOINT_ENV = "COMET_SAM3_CHECKPOINT"
+DEFAULT_CHECKPOINT_PATHS: tuple[str, ...] = (
+    "~/ws/models/weights/sam3.pt",
+    "~/ws/models/weights/sam3.1.pt",
+    "models/weights/sam3.pt",
+)
+
+
+def resolve_checkpoint(explicit: str | None = None) -> str | None:
+    """Find the SAM 3 weights file: explicit path, then env var, then defaults.
+
+    Returns None when nothing is found, which leaves upstream to download from
+    Hugging Face.  An explicit path that does not exist is an error rather than
+    a silent fallback — quietly downloading 800 MB because of a typo is worse
+    than failing.
+    """
+    if explicit:
+        p = Path(explicit).expanduser()
+        if not p.is_file():
+            raise FileNotFoundError(f"SAM 3 checkpoint not found: {p}")
+        return str(p)
+
+    env = os.environ.get(CHECKPOINT_ENV)
+    if env:
+        p = Path(env).expanduser()
+        if not p.is_file():
+            raise FileNotFoundError(
+                f"{CHECKPOINT_ENV} points at a missing file: {p}"
+            )
+        return str(p)
+
+    for cand in DEFAULT_CHECKPOINT_PATHS:
+        p = Path(cand).expanduser()
+        if p.is_file():
+            return str(p)
+    return None
 
 # Keys searched when pulling masks / ids / scores out of a frame's outputs.
 _MASK_KEYS  = ("pred_masks", "masks", "mask", "pred_mask", "masklets")
@@ -86,6 +128,7 @@ class Sam3Config:
 
     # Runtime
     gpus: list[int] | None = None    # None = every visible CUDA device
+    checkpoint: str | None = None    # local weights; None = search, then HF
     keep_masks: bool = False         # decode full masks at all
     # Called as sink(absolute_frame, obj_id, mask) for every mask, which is then
     # dropped from the Observation.  Masks are big — a 1080p boolean mask is
@@ -562,8 +605,24 @@ def build_predictor(cfg: Sam3Config):
         )
 
     gpus = cfg.gpus if cfg.gpus is not None else list(range(torch.cuda.device_count()))
+    kwargs = dict(cfg.extra_builder_kwargs)
+
+    # build_sam3_video_predictor(*args, gpus_to_use=None, **model_kwargs) forwards
+    # model_kwargs down to build_sam3_video_model, whose `checkpoint_path` short
+    # circuits its `load_from_HF=True` default.
+    ckpt = resolve_checkpoint(cfg.checkpoint)
+    if ckpt:
+        kwargs.setdefault("checkpoint_path", ckpt)
+        logging.info(f"SAM 3 checkpoint: {ckpt}")
+    else:
+        logging.info(
+            "No local SAM 3 checkpoint found "
+            f"(set {CHECKPOINT_ENV} or --checkpoint); "
+            "falling back to the gated Hugging Face download"
+        )
+
     logging.info(f"Building SAM 3 video predictor on GPUs {gpus}")
-    return build_sam3_video_predictor(gpus_to_use=gpus, **cfg.extra_builder_kwargs)
+    return build_sam3_video_predictor(gpus_to_use=gpus, **kwargs)
 
 
 # ── Orchestration ──────────────────────────────────────────────────────────────

--- a/src/sam3_preflight.py
+++ b/src/sam3_preflight.py
@@ -13,6 +13,18 @@ import importlib
 import platform
 import shutil
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from sam3_backend import (
+        CHECKPOINT_ENV, DEFAULT_CHECKPOINT_PATHS, resolve_checkpoint,
+    )
+except ImportError:
+    # numpy/cv2 missing — check_pipeline_deps() reports that as the real fault.
+    CHECKPOINT_ENV = "COMET_SAM3_CHECKPOINT"
+    DEFAULT_CHECKPOINT_PATHS = ()
+    resolve_checkpoint = None
 
 # (label, minimum) — from the upstream SAM 3 README.
 MIN_PYTHON = (3, 12)
@@ -87,6 +99,30 @@ def check_sam3() -> bool:
     return True
 
 
+def check_checkpoint() -> bool:
+    """Locate the weights file.  Not fatal — upstream can download instead."""
+    if resolve_checkpoint is None:
+        _line(WARN, "checkpoint", "skipped — pipeline deps missing")
+        return True
+
+    try:
+        ckpt = resolve_checkpoint()
+    except FileNotFoundError as e:
+        _line(FAIL, "checkpoint", str(e))
+        return False
+
+    if ckpt:
+        gb = Path(ckpt).stat().st_size / 1024 ** 3
+        _line(OK, "checkpoint", f"{ckpt} ({gb:.2f} GB)")
+        return True
+
+    searched = ", ".join(DEFAULT_CHECKPOINT_PATHS)
+    _line(WARN, "checkpoint",
+          f"no local weights (looked at ${CHECKPOINT_ENV}, then {searched}); "
+          f"SAM 3 will download the gated checkpoint from Hugging Face")
+    return True
+
+
 def check_pipeline_deps() -> bool:
     ok = True
     for mod in ("cv2", "numpy", "scipy"):
@@ -108,14 +144,17 @@ def main() -> int:
         check_pipeline_deps(),
         check_torch(),
         check_sam3(),
+        check_checkpoint(),
     ]
     print()
     if all(results):
         print("All checks passed — `python src/track_sam3.py` should run.")
         return 0
     print("Preflight failed. Fix the FAIL lines above, then re-run.")
-    print("Note: SAM 3 checkpoints are gated on Hugging Face — request access at")
-    print("      https://huggingface.co/facebook/sam3 and `huggingface-cli login`.")
+    print("If you have no local weights file, SAM 3 downloads a gated checkpoint:")
+    print("  request access at https://huggingface.co/facebook/sam3, then")
+    print("  `huggingface-cli login`.  A local file avoids this entirely — point")
+    print(f"  ${CHECKPOINT_ENV} or --checkpoint at it.")
     return 1
 
 

--- a/src/sam3_preflight.py
+++ b/src/sam3_preflight.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# sam3_preflight.py
+"""Check that this machine can actually run the SAM 3 backend.
+
+Run this before track_sam3.py — it fails in seconds with a specific reason,
+instead of a stack trace forty minutes into a frame extraction.
+
+    python src/sam3_preflight.py
+"""
+from __future__ import annotations
+
+import importlib
+import platform
+import shutil
+import sys
+
+# (label, minimum) — from the upstream SAM 3 README.
+MIN_PYTHON = (3, 12)
+MIN_TORCH  = (2, 7)
+MIN_CUDA   = (12, 6)
+
+OK, WARN, FAIL = "  ok  ", " warn ", " FAIL "
+
+
+def _line(status: str, label: str, detail: str = "") -> None:
+    print(f"[{status}] {label}" + (f" — {detail}" if detail else ""))
+
+
+def check_python() -> bool:
+    v = sys.version_info
+    got = f"{v.major}.{v.minor}.{v.micro}"
+    if (v.major, v.minor) >= MIN_PYTHON:
+        _line(OK, "python", got)
+        return True
+    _line(FAIL, "python", f"{got}, SAM 3 needs ≥ {MIN_PYTHON[0]}.{MIN_PYTHON[1]}")
+    return False
+
+
+def check_torch() -> bool:
+    try:
+        import torch
+    except ImportError:
+        _line(FAIL, "torch", "not installed — pip install -r requirements-sam3.txt")
+        return False
+
+    ver = torch.__version__.split("+")[0]
+    parts = tuple(int(x) for x in ver.split(".")[:2])
+    if parts >= MIN_TORCH:
+        _line(OK, "torch", ver)
+    else:
+        _line(FAIL, "torch", f"{ver}, SAM 3 needs ≥ {MIN_TORCH[0]}.{MIN_TORCH[1]}")
+        return False
+
+    if not torch.cuda.is_available():
+        _line(FAIL, "cuda", "torch.cuda.is_available() is False — SAM 3 video "
+                            "tracking needs a GPU")
+        return False
+
+    cuda_ver = torch.version.cuda or "unknown"
+    try:
+        cparts = tuple(int(x) for x in cuda_ver.split(".")[:2])
+        status = OK if cparts >= MIN_CUDA else WARN
+    except ValueError:
+        status = WARN
+    _line(status, "cuda", f"torch built against {cuda_ver} "
+                          f"(recommended ≥ {MIN_CUDA[0]}.{MIN_CUDA[1]})")
+
+    for i in range(torch.cuda.device_count()):
+        p = torch.cuda.get_device_properties(i)
+        gb = p.total_memory / 1024 ** 3
+        status = OK if gb >= 16 else WARN
+        _line(status, f"gpu{i}", f"{p.name}, {gb:.1f} GB")
+    return True
+
+
+def check_sam3() -> bool:
+    try:
+        mod = importlib.import_module("sam3.model_builder")
+    except ImportError as e:
+        _line(FAIL, "sam3", f"{e} — clone facebookresearch/sam3 and `pip install -e .`")
+        return False
+    if not hasattr(mod, "build_sam3_video_predictor"):
+        _line(FAIL, "sam3", "sam3.model_builder has no build_sam3_video_predictor — "
+                            "the installed sam3 is too old or is a different package")
+        return False
+    _line(OK, "sam3", "build_sam3_video_predictor importable")
+    return True
+
+
+def check_pipeline_deps() -> bool:
+    ok = True
+    for mod in ("cv2", "numpy", "scipy"):
+        try:
+            __import__(mod)
+            _line(OK, mod)
+        except ImportError:
+            _line(FAIL, mod, "pip install -r requirements.txt")
+            ok = False
+    _line(OK if shutil.which("ffmpeg") else WARN, "ffmpeg",
+          "found" if shutil.which("ffmpeg") else "missing — only to_webm.py needs it")
+    return ok
+
+
+def main() -> int:
+    print(f"Comet SAM 3 preflight — {platform.platform()}\n")
+    results = [
+        check_python(),
+        check_pipeline_deps(),
+        check_torch(),
+        check_sam3(),
+    ]
+    print()
+    if all(results):
+        print("All checks passed — `python src/track_sam3.py` should run.")
+        return 0
+    print("Preflight failed. Fix the FAIL lines above, then re-run.")
+    print("Note: SAM 3 checkpoints are gated on Hugging Face — request access at")
+    print("      https://huggingface.co/facebook/sam3 and `huggingface-cli login`.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/track.py
+++ b/src/track.py
@@ -3,6 +3,7 @@
 """Track objects using foreground detection + global Hungarian assignment."""
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import subprocess
@@ -13,9 +14,16 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from scipy.interpolate import UnivariateSpline
 from scipy.optimize import linear_sum_assignment as _scipy_lsa
-from scipy.signal import savgol_filter
+
+from trails import (
+    blend_trail,
+    box_center,
+    build_tracking_data,
+    smooth_pts,
+    write_tracking_json,
+)
+from trails import safe_append as _safe_append
 
 
 def _hungarian(cost: np.ndarray) -> list[tuple[int, int]]:
@@ -73,25 +81,9 @@ CLAMP_WHEN_LOST: set[str] = {"payload"}
 
 # ── Pure helpers ───────────────────────────────────────────────────────────────
 
-def box_center(x: int, y: int, w: int, h: int) -> tuple[int, int]:
-    return x + w // 2, y + h // 2
-
-
-def blend_trail(frame: np.ndarray, canvas: np.ndarray, alpha: float) -> np.ndarray:
-    mask = canvas.any(axis=2)
-    out  = frame.copy()
-    out[mask] = cv2.addWeighted(frame, 1 - alpha, canvas, alpha, 0)[mask]
-    return out
-
-
 def safe_append(trail: list, pt: tuple[int, int]) -> None:
-    if not trail:
-        trail.append(pt)
-        return
-    lx, ly = trail[-1]
-    if ((lx - pt[0]) ** 2 + (ly - pt[1]) ** 2) ** 0.5 > JUMP_THRESHOLD:
-        return
-    trail.append(pt)
+    """Module-local binding of the shared helper at this tracker's threshold."""
+    _safe_append(trail, pt, JUMP_THRESHOLD)
 
 
 def estimate_velocity(trail: list) -> tuple[float, float]:
@@ -361,110 +353,6 @@ def _replay_trail(
         logging.debug(f"Gap-fill: {name} interpolated {n} frames (only {len(sub)} detections found)")
 
 
-def _fill_gaps_bidirectional(
-    full_trail_log:      dict[str, dict[int, tuple[int, int]]],
-    full_det_log:        dict[int, list],
-    corridor_half_width: float = 80.0,
-    min_gap_frames:      int   = 5,
-    y_bands:             dict[str, tuple[float, float]] | None = None,
-) -> dict[str, dict[int, tuple[int, int]]]:
-    """
-    Post-process gap fill using both the gap start and end positions.
-
-    For each gap of ≥ min_gap_frames consecutive missing frames in an agent's
-    trail, we:
-      1. Define a corridor: points within `corridor_half_width` px of the
-         straight line between the gap's anchor and recovery positions.
-      2. For every gap frame, pick the nearest detection inside that corridor.
-      3. If ≥ 25 % of gap frames found a detection, use them (+ linear interp
-         for the remainder).  Otherwise fall back to pure linear interpolation.
-
-    Returns a dict {agent_name: {frame_idx: (cx, cy)}} that covers all frames
-    from the first to last tracked frame, gaps filled in.
-    """
-    result: dict[str, dict[int, tuple[int, int]]] = {}
-    for name, frame_pts in full_trail_log.items():
-        if not frame_pts:
-            result[name] = {}
-            continue
-
-        frames = sorted(frame_pts.keys())
-        filled: dict[int, tuple[int, int]] = dict(frame_pts)
-
-        for i in range(len(frames) - 1):
-            fa = frames[i]
-            fb = frames[i + 1]
-            gap_len = fb - fa - 1
-            if gap_len < min_gap_frames:
-                continue
-
-            start_pt = frame_pts[fa]
-            end_pt   = frame_pts[fb]
-            sx, sy   = start_pt
-            ex, ey   = end_pt
-            seg_dx   = ex - sx
-            seg_dy   = ey - sy
-            seg_len2 = seg_dx ** 2 + seg_dy ** 2
-
-            sub: dict[int, tuple[int, int]] = {}
-            y_lo, y_hi = (y_bands[name] if y_bands and name in y_bands
-                          else (-float("inf"), float("inf")))
-            for gf in range(fa + 1, fb):
-                dets    = full_det_log.get(gf, [])
-                best_d  = float("inf")
-                best_pt: tuple[int, int] | None = None
-                for dx, dy, dw, dh in dets:
-                    dcx = dx + dw / 2
-                    dcy = dy + dh / 2
-                    if not (y_lo <= dcy <= y_hi):
-                        continue
-                    # Perpendicular distance from detection to line segment
-                    if seg_len2 < 1.0:
-                        d_line = ((dcx - sx) ** 2 + (dcy - sy) ** 2) ** 0.5
-                    else:
-                        t = ((dcx - sx) * seg_dx + (dcy - sy) * seg_dy) / seg_len2
-                        t = max(0.0, min(1.0, t))
-                        d_line = ((dcx - (sx + t * seg_dx)) ** 2
-                                  + (dcy - (sy + t * seg_dy)) ** 2) ** 0.5
-                    if d_line < corridor_half_width and d_line < best_d:
-                        best_d  = d_line
-                        best_pt = (int(dcx), int(dcy))
-                if best_pt:
-                    sub[gf] = best_pt
-
-            gap_frames = list(range(fa + 1, fb))
-            if len(sub) >= max(1, len(gap_frames) * 0.25):
-                for gf in gap_frames:
-                    if gf in sub:
-                        filled[gf] = sub[gf]
-                    else:
-                        t = (gf - fa) / (fb - fa)
-                        filled[gf] = (int(sx + seg_dx * t), int(sy + seg_dy * t))
-            else:
-                for gf in gap_frames:
-                    t = (gf - fa) / (fb - fa)
-                    filled[gf] = (int(sx + seg_dx * t), int(sy + seg_dy * t))
-
-            logging.debug(
-                f"Gap-fill {name}: {fa}→{fb} ({gap_len} frames), "
-                f"det hits={len(sub)}/{len(gap_frames)}"
-            )
-
-        result[name] = filled
-    return result
-
-
-def smooth_pts(pts: list) -> list:
-    """Savitzky-Golay smooth for real-time trail rendering."""
-    n = len(pts)
-    if n < 5:
-        return list(pts)
-    win = min(15, n if n % 2 == 1 else n - 1)  # odd, <= n, >= 5
-    xs = savgol_filter([p[0] for p in pts], win, 3)
-    ys = savgol_filter([p[1] for p in pts], win, 3)
-    return [(int(x), int(y)) for x, y in zip(xs, ys)]
-
-
 def render_trails(canvas: np.ndarray, trails: dict[str, list], show: bool) -> None:
     if not show:
         return
@@ -520,40 +408,25 @@ def draw_debug(
     return out
 
 
-def spline_smooth(pts: list) -> list:
-    """
-    Global smoothing spline fitted to the full trail.
-    Used in post-processing where the complete trajectory is known.
-    UnivariateSpline (s > 0) does not interpolate exactly — it finds a smooth
-    curve that minimises squared residuals, which is exactly what we want for
-    noisy tracking data.
-    """
-    n = len(pts)
-    if n < 4:
-        return list(pts)
-    t    = np.arange(n, dtype=float)
-    xs   = np.array([p[0] for p in pts], dtype=float)
-    ys   = np.array([p[1] for p in pts], dtype=float)
-    s    = n * 4.0   # smoothing factor — larger → smoother curve
-    sp_x = UnivariateSpline(t, xs, s=s, k=3)
-    sp_y = UnivariateSpline(t, ys, s=s, k=3)
-    return [(int(float(sp_x(ti))), int(float(sp_y(ti)))) for ti in t]
-
-
-def filter_trail(trail: list, max_dev: int = 120) -> list:
-    if not trail:
-        return []
-    out = [trail[0]]
-    for p in trail[1:]:
-        lx, ly = out[-1]
-        if ((p[0] - lx) ** 2 + (p[1] - ly) ** 2) ** 0.5 <= max_dev:
-            out.append(p)
-    return out
-
-
 # ── Main ───────────────────────────────────────────────────────────────────────
 
-def main() -> None:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--no-display", action="store_true",
+                   help="run without a GUI window (required on headless machines)")
+    p.add_argument("--video", default=VIDEO_IN, help=f"input video (default: {VIDEO_IN})")
+    p.add_argument("--rois", default=ROIS_FILE, help=f"ROI file (default: {ROIS_FILE})")
+    p.add_argument("--out", default=VIDEO_OUT, help=f"output path stem (default: {VIDEO_OUT})")
+    return p.parse_args(argv)
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+    args = args or parse_args([])
+    video_in  = args.video
+    rois_file = args.rois
+    video_out = args.out
+    display   = not args.no_display
+
     # ── Logging ────────────────────────────────────────────────────────────────
     handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
     if LOG_TO_FILE:
@@ -564,22 +437,22 @@ def main() -> None:
     )
 
     # ── Load ROIs ──────────────────────────────────────────────────────────────
-    with open(ROIS_FILE) as f:
+    with open(rois_file) as f:
         raw = json.load(f)
     start_frame: int       = raw.get("start_frame", 0)   if isinstance(raw, dict) else 0
     end_frame:   int | None = raw.get("end_frame",   None) if isinstance(raw, dict) else None
     rois: dict              = raw["rois"] if isinstance(raw, dict) and "rois" in raw else raw
 
     # ── Optional input re-encode ───────────────────────────────────────────────
-    proc_video = VIDEO_IN
+    proc_video = video_in
     temp_mp4   = None
-    if not VIDEO_IN.lower().endswith(".mp4"):
+    if not video_in.lower().endswith(".mp4"):
         try:
             tmpf = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
             temp_mp4 = tmpf.name
             tmpf.close()
             r = subprocess.run(
-                ["ffmpeg", "-y", "-i", VIDEO_IN,
+                ["ffmpeg", "-y", "-i", video_in,
                  "-c:v", "libx264", "-crf", "18", "-preset", "fast", temp_mp4],
                 capture_output=True, timeout=300,
             )
@@ -626,7 +499,7 @@ def main() -> None:
     logging.debug("Background model built")
 
     # ── Save debug background images ────────────────────────────────────────────
-    dbg_dir = Path(VIDEO_OUT).parent
+    dbg_dir = Path(video_out).parent
     cv2.imwrite(str(dbg_dir / "debug_background.png"), bg_img)
     cv2.imwrite(str(dbg_dir / "debug_first_frame.png"), first_frame)
     # Foreground mask at start_frame — shows exactly which blobs the detector fires on
@@ -681,12 +554,13 @@ def main() -> None:
     full_trail_log: dict[str, dict[int, tuple[int, int]]] = {n: {} for n in states}
 
     frame_idx = start_frame + 1
-    cv2.namedWindow("Tracking", cv2.WINDOW_NORMAL)
-    cv2.resizeWindow("Tracking", 1600, 900)
+    if display:
+        cv2.namedWindow("Tracking", cv2.WINDOW_NORMAL)
+        cv2.resizeWindow("Tracking", 1600, 900)
     logging.debug(f"Tracking frames {start_frame}→{end_frame or total - 1}")
 
     # Debug writer covers only the tracked segment (start_frame → end_frame)
-    debug_out    = str(Path(VIDEO_OUT).with_name(Path(VIDEO_OUT).stem + "_debug.mp4"))
+    debug_out    = str(Path(video_out).with_name(Path(video_out).stem + "_debug.mp4"))
     debug_writer = cv2.VideoWriter(debug_out, fourcc_mp4, fps_v, (W, H))
 
     while True:
@@ -878,10 +752,11 @@ def main() -> None:
         annotated = blend_trail(frame, trail_canvas, ALPHA) if show_trail else frame.copy()
         dbg = draw_debug(annotated, states, frame_idx, total, fps_v)
         debug_writer.write(dbg)
-        cv2.imshow("Tracking", dbg)
-        if cv2.waitKey(1) & 0xFF in (ord("q"), 27):
-            logging.info("Quit early")
-            break
+        if display:
+            cv2.imshow("Tracking", dbg)
+            if cv2.waitKey(1) & 0xFF in (ord("q"), 27):
+                logging.info("Quit early")
+                break
 
         if frame_idx % 30 == 0:
             sys.stdout.write(f"\r  tracking {100 * frame_idx / total:.0f}%")
@@ -894,7 +769,8 @@ def main() -> None:
 
     cap.release()
     debug_writer.release()
-    cv2.destroyAllWindows()
+    if display:
+        cv2.destroyAllWindows()
     logging.info(f"Debug → {debug_out}")
 
     # ── Temp cleanup ───────────────────────────────────────────────────────────
@@ -905,31 +781,27 @@ def main() -> None:
             pass
 
     # ── Export tracking data for post-processing ───────────────────────────────
-    data_out = str(Path(VIDEO_OUT).with_name(Path(VIDEO_OUT).stem + "_tracking.json"))
-    tracking_data = {
-        "video_in":        VIDEO_IN,
-        "fps":             fps_v,
-        "total_frames":    total,
-        "width":           W,
-        "height":          H,
-        "start_frame":     start_frame,
-        "end_frame":       end_frame,
-        "trail_start_sec": trail_start_sec,
-        "trail_end_sec":   trail_end_sec,
-        "trail_color":     {k: list(v) for k, v in TRAIL_COLOR.items()},
-        "trail_thickness": TRAIL_THICKNESS,
-        "alpha":           ALPHA,
-        "trail_window":    TRAIL_WINDOW,
-        "smooth_trails":   SMOOTH_TRAILS,
-        "trails": {
-            name: {str(fi): list(pt) for fi, pt in fd.items()}
-            for name, fd in full_trail_log.items()
-        },
-    }
-    with open(data_out, "w") as f:
-        json.dump(tracking_data, f)
+    data_out = str(Path(video_out).with_name(Path(video_out).stem + "_tracking.json"))
+    tracking_data = build_tracking_data(
+        video_in        = video_in,
+        fps             = fps_v,
+        total_frames    = total,
+        width           = W,
+        height          = H,
+        start_frame     = start_frame,
+        end_frame       = end_frame,
+        trail_start_sec = trail_start_sec,
+        trail_end_sec   = trail_end_sec,
+        trail_color     = TRAIL_COLOR,
+        trail_thickness = TRAIL_THICKNESS,
+        alpha           = ALPHA,
+        trail_window    = TRAIL_WINDOW,
+        smooth_trails   = SMOOTH_TRAILS,
+        trails          = full_trail_log,
+    )
+    write_tracking_json(data_out, tracking_data)
     logging.info(f"Tracking data → {data_out}")
 
 
 if __name__ == "__main__":
-    main()
+    main(parse_args())

--- a/src/track_sam3.py
+++ b/src/track_sam3.py
@@ -302,6 +302,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--frames-dir", default=None,
                    help="keep extracted frames here instead of a temp dir")
     p.add_argument("--gpus", default=None, help="comma-separated CUDA device ids")
+    p.add_argument("--checkpoint", default=None, metavar="PATH",
+                   help="SAM 3 weights file. Defaults to $COMET_SAM3_CHECKPOINT, "
+                        "then ~/ws/models/weights/sam3.pt; if none is found, "
+                        "upstream downloads the gated checkpoint from HF")
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -358,6 +362,7 @@ def main(args: argparse.Namespace | None = None) -> None:
         chunk_size       = max(0, args.reprompt_every),
         chunk_overlap    = args.chunk_overlap,
         gpus             = [int(g) for g in _split(args.gpus)] or None,
+        checkpoint       = args.checkpoint,
         keep_masks       = want_masks,
     )
 

--- a/src/track_sam3.py
+++ b/src/track_sam3.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+# track_sam3.py
+"""Track objects with SAM 3, emitting Comet's standard tracking JSON.
+
+A drop-in alternative to track.py.  Same output contract, so render.py and
+to_webm.py are unchanged and the two trackers can be compared on one clip:
+
+    python src/track_sam3.py --out output/crazyflo_sam3.mp4
+    python src/render.py     output/crazyflo_sam3_tracking.json
+
+Two ways to say what to track:
+
+    --from-rois          (default) seed one object per box in src/rois.json.
+                         Keeps your cf1/cf2/cf3/payload identities.
+    --text "drone"       let the SAM 3 detector find every matching object.
+                         Names are assigned by first appearance: obj0, obj1, …
+                         Rename with --name 0=cf1 --name 1=cf2.
+
+Needs a CUDA GPU and the SAM 3 package — run `python src/sam3_preflight.py`
+first.  Everything except the model call is importable without torch.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from maskstore import MaskStore, sidecar_path
+from sam3_backend import (
+    FrameWindow,
+    Observation,
+    PromptSpec,
+    Sam3Config,
+    build_predictor,
+    discover_id_names,
+    observations_to_trails,
+    track_object_zoom,
+    track_window_chunked,
+)
+from trails import (
+    build_palette,
+    build_tracking_data,
+    fill_gaps_bidirectional,
+    write_tracking_json,
+)
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+VIDEO_IN  = "input/crazyflo.mp4"
+ROIS_FILE = "src/rois.json"
+VIDEO_OUT = "output/crazyflo_sam3.mp4"
+
+# Reused from track.py so both trackers render in the same colours.
+TRAIL_COLOR: dict[str, tuple[int, int, int]] = {
+    "cf1":     (  0,   0, 255),   # red
+    "cf2":     (  0, 255,   0),   # green
+    "cf3":     (255,   0,   0),   # blue
+    "payload": ( 50,  50,  50),
+}
+TRAIL_THICKNESS = 3
+DOT_RADIUS      = 5
+ALPHA           = 0.6
+TRAIL_START_SEC = 2
+TRAIL_END_SEC   = 2
+TRAIL_WINDOW    = 200
+SMOOTH_TRAILS   = True
+
+LOG_TO_FILE = True
+LOG_FILE    = "track_sam3.log"
+
+
+# ── ROI loading ────────────────────────────────────────────────────────────────
+
+def load_rois(path: str) -> tuple[int, int | None, dict[str, list[int]]]:
+    with open(path) as f:
+        raw = json.load(f)
+    if isinstance(raw, dict) and "rois" in raw:
+        return raw.get("start_frame", 0), raw.get("end_frame"), raw["rois"]
+    return 0, None, raw
+
+
+# ── Quality control ────────────────────────────────────────────────────────────
+
+def report_quality(
+    results: dict[int, dict[int, Observation]],
+    id_to_name: dict[int, str],
+) -> dict[str, dict]:
+    """Log per-object coverage, score and area stats; return them for the JSON.
+
+    Coverage is the number that matters: SAM 3 silently returning nothing for an
+    object is the failure mode that a glance at the trail video does not reveal,
+    because gap fill will have drawn a plausible straight line through it.
+    """
+    span = sorted(results)
+    if not span:
+        logging.warning("SAM 3 returned no frames at all")
+        return {}
+
+    stats: dict[str, dict] = {}
+    for oid, name in sorted(id_to_name.items(), key=lambda kv: kv[1]):
+        frames = [f for f in span if oid in results[f]]
+        scores = [results[f][oid].score for f in frames]
+        areas  = [results[f][oid].area  for f in frames]
+        cover  = len(frames) / len(span) if span else 0.0
+
+        # Longest run of consecutive tracked frames missing this object.
+        worst_gap = 0
+        run = 0
+        present = set(frames)
+        for f in span:
+            run = 0 if f in present else run + 1
+            worst_gap = max(worst_gap, run)
+
+        stats[name] = {
+            "obj_id":        oid,
+            "frames_seen":   len(frames),
+            "frames_total":  len(span),
+            "coverage":      round(cover, 4),
+            "longest_gap":   worst_gap,
+            "score_mean":    round(float(np.mean(scores)), 4) if scores else 0.0,
+            "score_min":     round(float(np.min(scores)),  4) if scores else 0.0,
+            "area_median":   int(np.median(areas)) if areas else 0,
+            "area_min":      int(np.min(areas))    if areas else 0,
+            "area_max":      int(np.max(areas))    if areas else 0,
+        }
+        level = logging.WARNING if cover < 0.9 or worst_gap > 15 else logging.INFO
+        logging.log(
+            level,
+            f"{name}: coverage {100 * cover:.1f}% ({len(frames)}/{len(span)}), "
+            f"longest gap {worst_gap} frames, score min/mean "
+            f"{stats[name]['score_min']:.2f}/{stats[name]['score_mean']:.2f}, "
+            f"area median {stats[name]['area_median']}px"
+        )
+        if stats[name]["area_median"] and stats[name]["area_max"] > 20 * stats[name]["area_median"]:
+            logging.warning(
+                f"{name}: mask area spikes to {stats[name]['area_max']}px vs median "
+                f"{stats[name]['area_median']}px — likely latched onto the background"
+            )
+    return stats
+
+
+# ── Debug video ────────────────────────────────────────────────────────────────
+
+def write_debug_video(
+    out_path: str,
+    window: FrameWindow,
+    results: dict[int, dict[int, Observation]],
+    id_to_name: dict[int, str],
+    color: dict[str, tuple[int, int, int]],
+    masks: MaskStore | None,
+    fps: float,
+) -> None:
+    """Annotated video: mask tint, bbox, label, score, and the trail so far."""
+    frames = sorted(results)
+    if not frames:
+        logging.warning("No results — skipping debug video")
+        return
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    writer = cv2.VideoWriter(
+        out_path, cv2.VideoWriter.fourcc(*"mp4v"), fps,
+        (window.width, window.height),
+    )
+    # VideoWriter reports failure only here — it does not raise, and every
+    # subsequent write() is silently discarded.
+    if not writer.isOpened():
+        logging.error(f"Cannot open debug video for writing: {out_path}")
+        return
+    history: dict[str, list[tuple[int, int]]] = {n: [] for n in id_to_name.values()}
+
+    for abs_idx in frames:
+        frame = window.read_frame(abs_idx)
+        if frame is None:
+            continue
+        per_obj = results[abs_idx]
+
+        for oid, obs in sorted(per_obj.items()):
+            name = id_to_name.get(oid, f"id{oid}")
+            col  = color.get(name, (255, 255, 255))
+            history.setdefault(name, []).append((obs.cx, obs.cy))
+
+            m = masks.get(abs_idx, name) if masks is not None else obs.mask
+            if m is not None and m.shape[:2] == frame.shape[:2]:
+                frame[m] = (frame[m] * 0.45 + np.array(col) * 0.55).astype(np.uint8)
+
+            x, y, w, h = obs.bbox
+            cv2.rectangle(frame, (x - 2, y - 2), (x + w + 2, y + h + 2), (0, 0, 0), 4)
+            cv2.rectangle(frame, (x, y), (x + w, y + h), col, 2)
+            cv2.circle(frame, (obs.cx, obs.cy), DOT_RADIUS + 3, (0, 0, 0), -1)
+            cv2.circle(frame, (obs.cx, obs.cy), DOT_RADIUS + 1, col, -1)
+
+            label = f"{name} {obs.score:.2f}"
+            pos   = (obs.cx + 10, obs.cy - 10)
+            cv2.putText(frame, label, pos, cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 0), 4)
+            cv2.putText(frame, label, pos, cv2.FONT_HERSHEY_SIMPLEX, 0.7, col, 1)
+
+        for name, pts in history.items():
+            if len(pts) >= 2:
+                cv2.polylines(frame, [np.array(pts, dtype=np.int32)], False,
+                              color.get(name, (255, 255, 255)), 2)
+
+        missing = [n for oid, n in id_to_name.items() if oid not in per_obj]
+        info = f"Frame {abs_idx}  SAM3  {len(per_obj)} obj"
+        if missing:
+            info += f"  MISSING: {','.join(sorted(missing))}"
+        cv2.putText(frame, info, (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 0, 0), 4)
+        cv2.putText(frame, info, (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (220, 220, 220), 1)
+        writer.write(frame)
+
+    writer.release()
+    logging.info(f"Debug → {out_path}")
+
+
+# ── Borrowed agents (hybrid mode) ──────────────────────────────────────────────
+
+def borrow_trails(
+    src_json: str, names: list[str],
+) -> dict[str, dict[int, tuple[int, int]]]:
+    """Lift named agents out of another tracking JSON (e.g. track.py's output).
+
+    Lets SAM 3 handle the well-defined objects while the background-subtraction
+    tracker keeps the one it is better at — the small low-contrast payload.
+    """
+    with open(src_json) as f:
+        d = json.load(f)
+    out: dict[str, dict[int, tuple[int, int]]] = {}
+    for name in names:
+        if name not in d.get("trails", {}):
+            raise KeyError(
+                f"--borrow-agents {name}: not in {src_json} "
+                f"(has {sorted(d.get('trails', {}))})"
+            )
+        out[name] = {int(f): tuple(p) for f, p in d["trails"][name].items()}
+        logging.info(f"Borrowed {name} from {src_json} ({len(out[name])} frames)")
+    return out
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────────
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--video", default=VIDEO_IN)
+    p.add_argument("--rois",  default=ROIS_FILE)
+    p.add_argument("--out",   default=VIDEO_OUT, help="output path stem")
+
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--from-rois", action="store_true", default=True,
+                      help="seed objects from rois.json boxes (default)")
+    mode.add_argument("--text", metavar="PROMPT",
+                      help='concept prompt, e.g. "drone" — discovers objects')
+
+    p.add_argument("--name", action="append", default=[], metavar="ID=NAME",
+                   help="rename a discovered object id (repeatable, --text mode)")
+    p.add_argument("--agents", default=None,
+                   help="comma-separated subset of rois.json agents to track")
+
+    p.add_argument("--start-frame", type=int, default=None,
+                   help="override rois.json start_frame")
+    p.add_argument("--end-frame", type=int, default=None,
+                   help="override rois.json end_frame")
+
+    p.add_argument("--prompt-shape", choices=("box", "point"), default="box",
+                   help="seed with the ROI box or with its centre point")
+    p.add_argument("--box-key", default=None,
+                   help="force the SAM 3 box-prompt keyword instead of probing")
+    p.add_argument("--norm-boxes", action="store_true",
+                   help="send prompt coordinates normalised to 0-1")
+    p.add_argument("--point-mode", choices=("centroid", "bbox"), default="centroid",
+                   help="reduce each mask to its barycentre or its bbox centre")
+
+    p.add_argument("--reprompt-every", type=int, default=0, metavar="N",
+                   help="re-seed every N frames; also caps memory-bank VRAM")
+    p.add_argument("--chunk-overlap", type=int, default=8)
+    p.add_argument("--min-score", type=float, default=0.0)
+    p.add_argument("--min-area", type=int, default=1)
+    p.add_argument("--mask-threshold", type=float, default=0.0)
+
+    p.add_argument("--zoom-agents", default=None, metavar="NAMES",
+                   help="comma-separated agents to re-track through an upscaled "
+                        "crop (for objects too small to survive downscaling)")
+    p.add_argument("--zoom-crop", type=int, default=384)
+    p.add_argument("--zoom-upscale", type=int, default=3)
+    p.add_argument("--zoom-segment", type=int, default=60)
+
+    p.add_argument("--borrow-agents", default=None, metavar="NAMES",
+                   help="comma-separated agents to take from --borrow-from instead")
+    p.add_argument("--borrow-from", default=None, metavar="JSON",
+                   help="tracking JSON to borrow those agents from")
+
+    p.add_argument("--no-gap-fill", action="store_true",
+                   help="leave dropouts as holes instead of interpolating")
+    p.add_argument("--min-gap-frames", type=int, default=5)
+    p.add_argument("--save-masks", action="store_true",
+                   help="write a *_masks.npz sidecar for render.py --mask-mode")
+    p.add_argument("--no-debug-video", action="store_true")
+    p.add_argument("--frames-dir", default=None,
+                   help="keep extracted frames here instead of a temp dir")
+    p.add_argument("--gpus", default=None, help="comma-separated CUDA device ids")
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p.parse_args(argv)
+
+
+def _split(csv: str | None) -> list[str]:
+    return [s.strip() for s in csv.split(",") if s.strip()] if csv else []
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+    args = args or parse_args([])
+
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+    if LOG_TO_FILE:
+        handlers.append(logging.FileHandler(LOG_FILE, mode="a"))
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO, handlers=handlers,
+        format="%(asctime)s %(levelname)s: %(message)s",
+    )
+
+    start_frame, end_frame, rois = load_rois(args.rois)
+    if args.start_frame is not None:
+        start_frame = args.start_frame
+    if args.end_frame is not None:
+        end_frame = args.end_frame
+
+    wanted = _split(args.agents)
+    if wanted:
+        missing = [n for n in wanted if n not in rois]
+        if missing:
+            sys.exit(f"--agents: {missing} not in {args.rois} (has {sorted(rois)})")
+        rois = {n: rois[n] for n in wanted}
+
+    borrow_names = _split(args.borrow_agents)
+    if borrow_names and not args.borrow_from:
+        sys.exit("--borrow-agents requires --borrow-from")
+    # Borrowed agents are supplied by the other tracker, so don't seed them here.
+    sam_rois = {n: b for n, b in rois.items() if n not in borrow_names}
+    if not sam_rois and args.text is None:
+        sys.exit("Nothing left for SAM 3 to track after --borrow-agents")
+
+    # Masks are needed for the sidecar and for the debug overlay.  They are
+    # never held as raw arrays: the sink run-length encodes each one on arrival
+    # and the Observation drops it, which is the difference between a few MB and
+    # several GB of resident memory on a 1080p clip.
+    want_masks = args.save_masks or not args.no_debug_video
+
+    cfg = Sam3Config(
+        normalize_coords = args.norm_boxes,
+        box_key          = args.box_key,
+        point_mode       = args.point_mode,
+        mask_threshold   = args.mask_threshold,
+        min_score        = args.min_score,
+        min_area         = args.min_area,
+        chunk_size       = max(0, args.reprompt_every),
+        chunk_overlap    = args.chunk_overlap,
+        gpus             = [int(g) for g in _split(args.gpus)] or None,
+        keep_masks       = want_masks,
+    )
+
+    window = FrameWindow(args.video, start_frame, end_frame)
+    try:
+        window.extract(args.frames_dir)
+
+        # Keyed by object id while tracking runs; renamed once the id → name
+        # mapping is known (text mode only settles it after propagation).
+        masks = MaskStore(window.height, window.width) if want_masks else None
+        if masks is not None:
+            cfg.mask_sink = lambda f, oid, m: masks.add(f, str(oid), m)
+
+        predictor = build_predictor(cfg)
+        try:
+            if args.text:
+                results = track_window_chunked(
+                    window, cfg, predictor=predictor, text=args.text,
+                )
+                name_map = {}
+                for spec in args.name:
+                    if "=" not in spec:
+                        sys.exit(f"--name expects ID=NAME, got {spec!r}")
+                    k, v = spec.split("=", 1)
+                    name_map[int(k)] = v
+                id_to_name = discover_id_names(results, name_map=name_map)
+                logging.info(
+                    f"Discovered {len(id_to_name)} object(s): "
+                    + ", ".join(f"{o}→{n}" for o, n in sorted(id_to_name.items()))
+                )
+            else:
+                prompts = [
+                    PromptSpec(name=name, obj_id=i, box=tuple(float(v) for v in box))
+                    for i, (name, box) in enumerate(sorted(sam_rois.items()))
+                ]
+                id_to_name = {p.obj_id: p.name for p in prompts}
+                results = track_window_chunked(
+                    window, cfg, predictor=predictor, prompts=prompts,
+                    prompt_shape=args.prompt_shape,
+                )
+
+            # ── Zoom pass for objects too small to track at full frame ────────
+            for name in _split(args.zoom_agents):
+                oid = next((o for o, n in id_to_name.items() if n == name), None)
+                if oid is None:
+                    sys.exit(f"--zoom-agents: unknown agent {name!r}")
+                if name not in rois:
+                    sys.exit(f"--zoom-agents {name}: no seed box in {args.rois}")
+                logging.info(f"Zoom-tracking {name} (crop {args.zoom_crop}px "
+                             f"×{args.zoom_upscale})")
+                zoom = track_object_zoom(
+                    window, cfg, tuple(float(v) for v in rois[name]), oid,
+                    predictor=predictor, crop_size=args.zoom_crop,
+                    upscale=args.zoom_upscale, segment_len=args.zoom_segment,
+                )
+                replaced = 0
+                for abs_idx, obs in zoom.items():
+                    results.setdefault(abs_idx, {})[oid] = obs
+                    replaced += 1
+                logging.info(f"Zoom pass supplied {replaced} frames for {name}")
+        finally:
+            if hasattr(predictor, "shutdown"):
+                try:
+                    predictor.shutdown()
+                except Exception as e:          # noqa: BLE001 - cleanup only
+                    logging.warning(f"predictor.shutdown() failed: {e}")
+
+        stats = report_quality(results, id_to_name)
+
+        if masks is not None:
+            masks.rename({str(oid): name for oid, name in id_to_name.items()})
+
+        # ── Debug video ───────────────────────────────────────────────────────
+        if not args.no_debug_video:
+            debug_out = str(Path(args.out).with_name(
+                Path(args.out).stem + "_debug.mp4"))
+            write_debug_video(debug_out, window, results, id_to_name,
+                              build_palette(list(id_to_name.values()), TRAIL_COLOR),
+                              masks, window.fps)
+
+        # ── Trails ────────────────────────────────────────────────────────────
+        trails = observations_to_trails(results, id_to_name)
+        if borrow_names:
+            trails.update(borrow_trails(args.borrow_from, borrow_names))
+
+        if not args.no_gap_fill:
+            before = {n: len(t) for n, t in trails.items()}
+            # No detection corridor to search: SAM 3 gives us tracked objects,
+            # not a pool of candidate blobs, so holes resolve to interpolation
+            # between the frames on either side.
+            trails = fill_gaps_bidirectional(
+                trails, {}, min_gap_frames=args.min_gap_frames,
+            )
+            for n, t in trails.items():
+                if len(t) > before.get(n, 0):
+                    logging.info(
+                        f"{n}: interpolated {len(t) - before[n]} gap frames"
+                    )
+
+        color = build_palette(sorted(trails), TRAIL_COLOR)
+        data = build_tracking_data(
+            video_in        = args.video,
+            fps             = window.fps,
+            total_frames    = window.total_frames,
+            width           = window.width,
+            height          = window.height,
+            start_frame     = start_frame,
+            end_frame       = end_frame,
+            trail_start_sec = TRAIL_START_SEC,
+            trail_end_sec   = TRAIL_END_SEC,
+            trail_color     = color,
+            trail_thickness = TRAIL_THICKNESS,
+            alpha           = ALPHA,
+            trail_window    = TRAIL_WINDOW,
+            smooth_trails   = SMOOTH_TRAILS,
+            trails          = trails,
+            extra           = {
+                "tracker":     "sam3",
+                "sam3_prompt": {"text": args.text} if args.text
+                               else {"rois": sorted(sam_rois)},
+                "sam3_stats":  stats,
+            },
+        )
+        data_out = str(Path(args.out).with_name(
+            Path(args.out).stem + "_tracking.json"))
+        write_tracking_json(data_out, data)
+        logging.info(f"Tracking data → {data_out}")
+
+        if masks is not None and args.save_masks:
+            mp = masks.save(sidecar_path(data_out))
+            logging.info(f"Masks → {mp} ({len(masks)} masks)")
+    finally:
+        if args.frames_dir is None:
+            window.cleanup()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/src/trails.py
+++ b/src/trails.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+# trails.py
+"""Shared trail geometry, smoothing, gap-fill and tracking-JSON I/O.
+
+Extracted from track.py so that every tracker backend (background subtraction
+in track.py, SAM 3 in track_sam3.py) produces byte-compatible tracking data and
+render.py has a single implementation to consume.
+
+The tracking JSON contract — every backend must emit exactly this:
+
+    {
+      "video_in": str, "fps": float, "total_frames": int,
+      "width": int, "height": int,
+      "start_frame": int, "end_frame": int | null,
+      "trail_start_sec": float, "trail_end_sec": float,
+      "trail_color": {agent: [b, g, r]},
+      "trail_thickness": int, "alpha": float, "trail_window": int,
+      "smooth_trails": bool,
+      "trails": {agent: {"<frame_idx>": [cx, cy]}}
+    }
+
+`trails` is keyed by ABSOLUTE frame index in the source video (a string, since
+JSON object keys are strings), not by an index into any extracted sub-range.
+render.py walks `range(total_frames)` of the original video and matches on
+these keys, so an off-by-start_frame error here silently desynchronises every
+trail from the footage.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from scipy.interpolate import UnivariateSpline
+from scipy.signal import savgol_filter
+
+
+# ── Geometry ───────────────────────────────────────────────────────────────────
+
+def box_center(x: int, y: int, w: int, h: int) -> tuple[int, int]:
+    return x + w // 2, y + h // 2
+
+
+def safe_append(trail: list, pt: tuple[int, int], jump_threshold: float) -> None:
+    """Append `pt` unless it is a teleport away from the last point."""
+    if not trail:
+        trail.append(pt)
+        return
+    lx, ly = trail[-1]
+    if ((lx - pt[0]) ** 2 + (ly - pt[1]) ** 2) ** 0.5 > jump_threshold:
+        return
+    trail.append(pt)
+
+
+def filter_trail(trail: list, max_dev: int = 120) -> list:
+    if not trail:
+        return []
+    out = [trail[0]]
+    for p in trail[1:]:
+        lx, ly = out[-1]
+        if ((p[0] - lx) ** 2 + (p[1] - ly) ** 2) ** 0.5 <= max_dev:
+            out.append(p)
+    return out
+
+
+# ── Smoothing ──────────────────────────────────────────────────────────────────
+
+def smooth_pts(pts: list) -> list:
+    """Savitzky-Golay smooth for real-time trail rendering."""
+    n = len(pts)
+    if n < 5:
+        return list(pts)
+    win = min(15, n if n % 2 == 1 else n - 1)  # odd, <= n, >= 5
+    xs = savgol_filter([p[0] for p in pts], win, 3)
+    ys = savgol_filter([p[1] for p in pts], win, 3)
+    return [(int(x), int(y)) for x, y in zip(xs, ys)]
+
+
+def spline_smooth(pts: list) -> list:
+    """
+    Global smoothing spline fitted to the full trail.
+    Used in post-processing where the complete trajectory is known.
+    UnivariateSpline (s > 0) does not interpolate exactly — it finds a smooth
+    curve that minimises squared residuals, which is exactly what we want for
+    noisy tracking data.
+    """
+    n = len(pts)
+    if n < 4:
+        return list(pts)
+    t    = np.arange(n, dtype=float)
+    xs   = np.array([p[0] for p in pts], dtype=float)
+    ys   = np.array([p[1] for p in pts], dtype=float)
+    s    = n * 4.0   # smoothing factor — larger → smoother curve
+    sp_x = UnivariateSpline(t, xs, s=s, k=3)
+    sp_y = UnivariateSpline(t, ys, s=s, k=3)
+    return [(int(float(sp_x(ti))), int(float(sp_y(ti)))) for ti in t]
+
+
+# ── Compositing ────────────────────────────────────────────────────────────────
+
+def blend_trail(frame: np.ndarray, canvas: np.ndarray, alpha: float) -> np.ndarray:
+    mask = canvas.any(axis=2)
+    out  = frame.copy()
+    out[mask] = cv2.addWeighted(frame, 1 - alpha, canvas, alpha, 0)[mask]
+    return out
+
+
+# ── Gap fill ───────────────────────────────────────────────────────────────────
+
+def fill_gaps_bidirectional(
+    full_trail_log:      dict[str, dict[int, tuple[int, int]]],
+    full_det_log:        dict[int, list],
+    corridor_half_width: float = 80.0,
+    min_gap_frames:      int   = 5,
+    y_bands:             dict[str, tuple[float, float]] | None = None,
+) -> dict[str, dict[int, tuple[int, int]]]:
+    """
+    Post-process gap fill using both the gap start and end positions.
+
+    For each gap of ≥ min_gap_frames consecutive missing frames in an agent's
+    trail, we:
+      1. Define a corridor: points within `corridor_half_width` px of the
+         straight line between the gap's anchor and recovery positions.
+      2. For every gap frame, pick the nearest detection inside that corridor.
+      3. If ≥ 25 % of gap frames found a detection, use them (+ linear interp
+         for the remainder).  Otherwise fall back to pure linear interpolation.
+
+    `full_det_log` maps frame index → list of (x, y, w, h) candidate boxes.  A
+    SAM 3 backend can pass an empty dict, in which case every gap resolves to
+    linear interpolation between the known endpoints.
+
+    Returns a dict {agent_name: {frame_idx: (cx, cy)}} that covers all frames
+    from the first to last tracked frame, gaps filled in.
+    """
+    result: dict[str, dict[int, tuple[int, int]]] = {}
+    for name, frame_pts in full_trail_log.items():
+        if not frame_pts:
+            result[name] = {}
+            continue
+
+        frames = sorted(frame_pts.keys())
+        filled: dict[int, tuple[int, int]] = dict(frame_pts)
+
+        for i in range(len(frames) - 1):
+            fa = frames[i]
+            fb = frames[i + 1]
+            gap_len = fb - fa - 1
+            if gap_len < min_gap_frames:
+                continue
+
+            start_pt = frame_pts[fa]
+            end_pt   = frame_pts[fb]
+            sx, sy   = start_pt
+            ex, ey   = end_pt
+            seg_dx   = ex - sx
+            seg_dy   = ey - sy
+            seg_len2 = seg_dx ** 2 + seg_dy ** 2
+
+            sub: dict[int, tuple[int, int]] = {}
+            y_lo, y_hi = (y_bands[name] if y_bands and name in y_bands
+                          else (-float("inf"), float("inf")))
+            for gf in range(fa + 1, fb):
+                dets    = full_det_log.get(gf, [])
+                best_d  = float("inf")
+                best_pt: tuple[int, int] | None = None
+                for dx, dy, dw, dh in dets:
+                    dcx = dx + dw / 2
+                    dcy = dy + dh / 2
+                    if not (y_lo <= dcy <= y_hi):
+                        continue
+                    # Perpendicular distance from detection to line segment
+                    if seg_len2 < 1.0:
+                        d_line = ((dcx - sx) ** 2 + (dcy - sy) ** 2) ** 0.5
+                    else:
+                        t = ((dcx - sx) * seg_dx + (dcy - sy) * seg_dy) / seg_len2
+                        t = max(0.0, min(1.0, t))
+                        d_line = ((dcx - (sx + t * seg_dx)) ** 2
+                                  + (dcy - (sy + t * seg_dy)) ** 2) ** 0.5
+                    if d_line < corridor_half_width and d_line < best_d:
+                        best_d  = d_line
+                        best_pt = (int(dcx), int(dcy))
+                if best_pt:
+                    sub[gf] = best_pt
+
+            gap_frames = list(range(fa + 1, fb))
+            if len(sub) >= max(1, len(gap_frames) * 0.25):
+                for gf in gap_frames:
+                    if gf in sub:
+                        filled[gf] = sub[gf]
+                    else:
+                        t = (gf - fa) / (fb - fa)
+                        filled[gf] = (int(sx + seg_dx * t), int(sy + seg_dy * t))
+            else:
+                for gf in gap_frames:
+                    t = (gf - fa) / (fb - fa)
+                    filled[gf] = (int(sx + seg_dx * t), int(sy + seg_dy * t))
+
+            logging.debug(
+                f"Gap-fill {name}: {fa}→{fb} ({gap_len} frames), "
+                f"det hits={len(sub)}/{len(gap_frames)}"
+            )
+
+        result[name] = filled
+    return result
+
+
+# ── Palette ────────────────────────────────────────────────────────────────────
+
+# Distinct BGR colours for agents that have no explicit entry (text-prompt mode
+# discovers objects at runtime, so their names are not known in advance).
+FALLBACK_PALETTE: list[tuple[int, int, int]] = [
+    (  0,   0, 255),   # red
+    (  0, 255,   0),   # green
+    (255,   0,   0),   # blue
+    (  0, 255, 255),   # yellow
+    (255,   0, 255),   # magenta
+    (255, 255,   0),   # cyan
+    (  0, 128, 255),   # orange
+    (128,   0, 255),   # pink
+    (255, 128,   0),   # azure
+    (128, 255,   0),   # spring
+]
+
+
+def build_palette(
+    names: list[str],
+    explicit: dict[str, tuple[int, int, int]] | None = None,
+) -> dict[str, tuple[int, int, int]]:
+    """Colour for every name, preferring `explicit` and cycling the fallback.
+
+    render.py indexes `trail_color[name]` unconditionally, so a name missing
+    from this dict is a KeyError at render time rather than a missing trail.
+    """
+    explicit = explicit or {}
+    out: dict[str, tuple[int, int, int]] = {}
+    nxt = 0
+    for name in names:
+        if name in explicit:
+            out[name] = tuple(explicit[name])
+        else:
+            out[name] = FALLBACK_PALETTE[nxt % len(FALLBACK_PALETTE)]
+            nxt += 1
+    return out
+
+
+# ── Tracking JSON I/O ──────────────────────────────────────────────────────────
+
+def build_tracking_data(
+    *,
+    video_in:        str,
+    fps:             float,
+    total_frames:    int,
+    width:           int,
+    height:          int,
+    start_frame:     int,
+    end_frame:       int | None,
+    trail_start_sec: float,
+    trail_end_sec:   float,
+    trail_color:     dict[str, tuple[int, int, int]],
+    trail_thickness: int,
+    alpha:           float,
+    trail_window:    int,
+    smooth_trails:   bool,
+    trails:          dict[str, dict[int, tuple[int, int]]],
+    extra:           dict | None = None,
+) -> dict:
+    """Assemble the tracking dict in the exact schema render.py expects."""
+    data = {
+        "video_in":        video_in,
+        "fps":             fps,
+        "total_frames":    total_frames,
+        "width":           width,
+        "height":          height,
+        "start_frame":     start_frame,
+        "end_frame":       end_frame,
+        "trail_start_sec": trail_start_sec,
+        "trail_end_sec":   trail_end_sec,
+        "trail_color":     {k: list(v) for k, v in trail_color.items()},
+        "trail_thickness": trail_thickness,
+        "alpha":           alpha,
+        "trail_window":    trail_window,
+        "smooth_trails":   smooth_trails,
+        "trails": {
+            name: {str(fi): list(pt) for fi, pt in sorted(fd.items())}
+            for name, fd in trails.items()
+        },
+    }
+    if extra:
+        data.update(extra)
+    return data
+
+
+def write_tracking_json(path: str | Path, data: dict) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f)
+    return path

--- a/tests/fake_sam3.py
+++ b/tests/fake_sam3.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# tests/fake_sam3.py
+"""A stand-in for Sam3VideoPredictor.
+
+Implements the same request/response protocol as the real predictor so the
+plumbing around SAM 3 — index mapping, prompt dispatch, output normalisation,
+chunking, trail assembly — can be tested on a machine with no GPU.
+
+It moves each prompted object along a straight line at a fixed velocity and
+paints a filled circle for its mask, so the expected trail is exactly
+predictable.  `output_layout` selects which of the response shapes SAM 3
+wrappers emit, and `drop_frames` simulates dropouts.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+class FakePredictor:
+    def __init__(
+        self,
+        height: int = 120,
+        width: int = 160,
+        n_frames: int = 20,
+        radius: int = 5,
+        velocity: tuple[float, float] = (2.0, 1.0),
+        output_layout: str = "arrays",     # arrays | mapping | mapping_dict | attrs
+        mask_dtype: str = "bool",          # bool | logits | probs
+        drop_frames: dict[int, set[int]] | None = None,   # local_idx → obj_ids
+        box_key: str = "box",              # which keyword this build accepts
+        mask_scale: float = 1.0,           # emit masks at a different resolution
+    ):
+        self.height, self.width = height, width
+        self.n_frames = n_frames
+        self.radius = radius
+        self.velocity = velocity
+        self.output_layout = output_layout
+        self.mask_dtype = mask_dtype
+        self.drop_frames = drop_frames or {}
+        self.box_key = box_key
+        self.mask_scale = mask_scale
+
+        self.sessions: dict[str, dict] = {}
+        self._next = 0
+        self.shutdown_calls = 0
+        self.requests: list[dict] = []
+
+    # -- protocol -------------------------------------------------------------
+    def handle_request(self, request: dict):
+        self.requests.append(dict(request))
+        kind = request["type"]
+
+        if kind == "start_session":
+            sid = f"sess{self._next}"
+            self._next += 1
+            self.sessions[sid] = {"seeds": {}, "resource": request["resource_path"]}
+            return {"session_id": sid}
+
+        if kind == "reset_session":
+            self.sessions[request["session_id"]]["seeds"] = {}
+            return {}
+
+        if kind == "close_session":
+            self.sessions.pop(request["session_id"], None)
+            return {}
+
+        if kind == "add_prompt":
+            sess = self.sessions[request["session_id"]]
+            if "text" in request:
+                # Concept prompt: the "detector" finds two objects.
+                sess["seeds"][0] = (self.width * 0.2, self.height * 0.2)
+                sess["seeds"][1] = (self.width * 0.5, self.height * 0.3)
+                return {"outputs": None}
+
+            present = [k for k in ("box", "boxes", "bbox", "input_boxes")
+                       if k in request]
+            if present:
+                if self.box_key not in request:
+                    raise TypeError(
+                        f"unexpected keyword {present[0]!r}; this build wants "
+                        f"{self.box_key!r}"
+                    )
+                b = np.asarray(request[self.box_key]).reshape(-1)
+                cx = (float(b[0]) + float(b[2])) / 2
+                cy = (float(b[1]) + float(b[3])) / 2
+            elif "points" in request:
+                p = np.asarray(request["points"]).reshape(-1, 2)
+                cx, cy = float(p[0][0]), float(p[0][1])
+            else:
+                raise TypeError(f"no usable prompt in {sorted(request)}")
+
+            sess["seeds"][int(request["obj_id"])] = (cx, cy)
+            return {"outputs": None}
+
+        raise ValueError(f"FakePredictor got unknown request type {kind!r}")
+
+    def handle_stream_request(self, request: dict):
+        assert request["type"] == "propagate_in_video"
+        sess = self.sessions[request["session_id"]]
+        n = self._frames_in(sess["resource"])
+        for i in range(n):
+            yield {"frame_index": i, "outputs": self._outputs(sess["seeds"], i)}
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+
+    # -- helpers --------------------------------------------------------------
+    def _frames_in(self, resource) -> int:
+        from pathlib import Path
+        p = Path(resource)
+        if p.is_dir():
+            found = len(list(p.glob("*.jpg")))
+            if found:
+                return found
+        return self.n_frames
+
+    def position(self, seed: tuple[float, float], i: int) -> tuple[float, float]:
+        # Clamped to keep the whole circle on screen: an object drifting out of
+        # frame would produce an empty mask, which reads as a dropout and would
+        # make coverage assertions depend on clip length rather than on the
+        # behaviour under test.  Real dropouts are injected via drop_frames.
+        x = seed[0] + self.velocity[0] * i
+        y = seed[1] + self.velocity[1] * i
+        r = self.radius
+        return (min(max(x, r), self.width - r - 1),
+                min(max(y, r), self.height - r - 1))
+
+    def _circle(self, cx: float, cy: float) -> np.ndarray:
+        h = int(self.height * self.mask_scale)
+        w = int(self.width * self.mask_scale)
+        yy, xx = np.mgrid[0:h, 0:w]
+        m = ((xx - cx * self.mask_scale) ** 2
+             + (yy - cy * self.mask_scale) ** 2) <= (self.radius * self.mask_scale) ** 2
+        if self.mask_dtype == "bool":
+            return m
+        if self.mask_dtype == "probs":
+            return np.where(m, 0.9, 0.1).astype(np.float32)
+        return np.where(m, 4.0, -4.0).astype(np.float32)     # logits
+
+    def _outputs(self, seeds: dict[int, tuple[float, float]], i: int):
+        dropped = self.drop_frames.get(i, set())
+        ids, masks, scores = [], [], []
+        for oid, seed in sorted(seeds.items()):
+            if oid in dropped:
+                continue
+            cx, cy = self.position(seed, i)
+            ids.append(oid)
+            masks.append(self._circle(cx, cy))
+            scores.append(0.9)
+
+        if self.output_layout == "arrays":
+            if not ids:
+                return {"pred_masks": np.zeros((0, 1, 1)), "obj_ids": [],
+                        "scores": []}
+            # [N, 1, H, W] — the channel axis the real decoder emits.
+            return {"pred_masks": np.stack(masks)[:, None],
+                    "obj_ids": ids, "scores": scores}
+
+        if self.output_layout == "mapping":
+            return {oid: m for oid, m in zip(ids, masks)}
+
+        if self.output_layout == "mapping_dict":
+            return {oid: {"mask": m, "score": s}
+                    for oid, m, s in zip(ids, masks, scores)}
+
+        if self.output_layout == "attrs":
+            class _Out:
+                pass
+            o = _Out()
+            o.masks = np.stack(masks) if masks else np.zeros((0, 1, 1))
+            o.object_ids = ids
+            o.scores = scores
+            return o
+
+        raise ValueError(self.output_layout)

--- a/tests/test_sam3_backend.py
+++ b/tests/test_sam3_backend.py
@@ -11,10 +11,12 @@ verify SAM 3's tracking quality; that needs a GPU and the real checkpoint.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 
@@ -27,6 +29,7 @@ from fake_sam3 import FakePredictor                         # noqa: E402
 
 from maskstore import MaskStore, decode_rle, encode_rle, sidecar_path   # noqa: E402
 from sam3_backend import (                                  # noqa: E402
+    CHECKPOINT_ENV,
     FrameWindow,
     Observation,
     PromptSpec,
@@ -36,6 +39,7 @@ from sam3_backend import (                                  # noqa: E402
     mask_to_observation,
     normalize_frame_outputs,
     observations_to_trails,
+    resolve_checkpoint,
     track_window,
     track_window_chunked,
 )
@@ -572,6 +576,58 @@ class TestTrackingJsonContract(unittest.TestCase):
 
 
 # ── Mask store ─────────────────────────────────────────────────────────────────
+
+class TestResolveCheckpoint(unittest.TestCase):
+    """Weights lookup: explicit path, then $COMET_SAM3_CHECKPOINT, then defaults."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ckpt = Path(self.tmp.name) / "sam3.pt"
+        self.ckpt.write_bytes(b"weights")
+        self._env = os.environ.pop(CHECKPOINT_ENV, None)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+        os.environ.pop(CHECKPOINT_ENV, None)
+        if self._env is not None:
+            os.environ[CHECKPOINT_ENV] = self._env
+
+    def test_explicit_path_wins(self):
+        other = Path(self.tmp.name) / "other.pt"
+        other.write_bytes(b"w")
+        os.environ[CHECKPOINT_ENV] = str(other)
+        self.assertEqual(resolve_checkpoint(str(self.ckpt)), str(self.ckpt))
+
+    def test_env_var_used_when_no_explicit_path(self):
+        os.environ[CHECKPOINT_ENV] = str(self.ckpt)
+        self.assertEqual(resolve_checkpoint(), str(self.ckpt))
+
+    def test_tilde_is_expanded(self):
+        os.environ[CHECKPOINT_ENV] = str(self.ckpt).replace(
+            str(Path.home()), "~", 1)
+        if os.environ[CHECKPOINT_ENV].startswith("~"):
+            self.assertEqual(resolve_checkpoint(), str(self.ckpt))
+
+    def test_missing_explicit_path_raises_instead_of_downloading(self):
+        # A typo must not silently trigger an 800 MB gated download.
+        with self.assertRaises(FileNotFoundError):
+            resolve_checkpoint(str(Path(self.tmp.name) / "nope.pt"))
+
+    def test_missing_env_path_raises(self):
+        os.environ[CHECKPOINT_ENV] = str(Path(self.tmp.name) / "nope.pt")
+        with self.assertRaises(FileNotFoundError):
+            resolve_checkpoint()
+
+    def test_none_when_nothing_found(self):
+        with mock.patch("sam3_backend.DEFAULT_CHECKPOINT_PATHS",
+                        (str(Path(self.tmp.name) / "absent.pt"),)):
+            self.assertIsNone(resolve_checkpoint())
+
+    def test_falls_back_to_default_search_paths(self):
+        with mock.patch("sam3_backend.DEFAULT_CHECKPOINT_PATHS",
+                        ("/definitely/absent.pt", str(self.ckpt))):
+            self.assertEqual(resolve_checkpoint(), str(self.ckpt))
+
 
 class TestMaskStore(unittest.TestCase):
     def test_rle_roundtrip(self):

--- a/tests/test_sam3_backend.py
+++ b/tests/test_sam3_backend.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+# tests/test_sam3_backend.py
+"""Tests for the SAM 3 backend plumbing, using a fake predictor.
+
+These cover everything around the model — index mapping, prompt dispatch,
+output normalisation, chunking, trail assembly, mask storage.  They cannot
+verify SAM 3's tracking quality; that needs a GPU and the real checkpoint.
+
+    python -m unittest discover -s tests -v
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cv2                                                  # noqa: E402
+from fake_sam3 import FakePredictor                         # noqa: E402
+
+from maskstore import MaskStore, decode_rle, encode_rle, sidecar_path   # noqa: E402
+from sam3_backend import (                                  # noqa: E402
+    FrameWindow,
+    Observation,
+    PromptSpec,
+    Sam3Config,
+    binarize_mask,
+    discover_id_names,
+    mask_to_observation,
+    normalize_frame_outputs,
+    observations_to_trails,
+    track_window,
+    track_window_chunked,
+)
+from trails import (                                        # noqa: E402
+    build_palette,
+    build_tracking_data,
+    fill_gaps_bidirectional,
+)
+
+
+BAR_W, BAR_STEP = 6, 2
+
+
+def make_video(path: Path, n_frames: int, w: int = 160, h: int = 120) -> None:
+    """Synthetic clip whose frame index is encoded as a bar's x position.
+
+    Position survives lossy inter-frame coding; a flat grey level does not —
+    mp4v shifts a uniform fill by several counts, so encoding the index in
+    pixel VALUE would test the codec rather than the frame indexing.
+    """
+    wr = cv2.VideoWriter(str(path), cv2.VideoWriter.fourcc(*"mp4v"), 30.0, (w, h))
+    for i in range(n_frames):
+        f = np.zeros((h, w, 3), dtype=np.uint8)
+        x = (i * BAR_STEP) % (w - BAR_W)
+        cv2.rectangle(f, (x, 40), (x + BAR_W, 80), (255, 255, 255), -1)
+        wr.write(f)
+    wr.release()
+
+
+def frame_index_of(img: np.ndarray) -> int:
+    """Recover the index `make_video` encoded into a frame."""
+    xs = np.nonzero((img[:, :, 0] > 128).any(axis=0))[0]
+    if xs.size == 0:
+        return -1
+    return round((float(xs.mean()) - BAR_W / 2) / BAR_STEP)
+
+
+# ── Mask reduction ─────────────────────────────────────────────────────────────
+
+class TestMaskReduction(unittest.TestCase):
+    def test_binarize_bool_passthrough(self):
+        m = np.zeros((4, 4), dtype=bool)
+        m[1, 1] = True
+        self.assertTrue(np.array_equal(binarize_mask(m), m))
+
+    def test_binarize_logits_split_at_zero(self):
+        raw = np.array([[-4.0, 4.0], [0.5, -0.5]], dtype=np.float32)
+        self.assertEqual(binarize_mask(raw).tolist(), [[False, True], [True, False]])
+
+    def test_binarize_probabilities_split_at_half(self):
+        # Values inside [0, 1] are probabilities: a 0.4 must NOT be foreground,
+        # which a naive >0 threshold would get wrong.
+        raw = np.array([[0.1, 0.9], [0.4, 0.6]], dtype=np.float32)
+        self.assertEqual(binarize_mask(raw).tolist(), [[False, True], [False, True]])
+
+    def test_binarize_squeezes_leading_axes(self):
+        m = np.zeros((1, 1, 3, 3), dtype=bool)
+        m[0, 0, 2, 2] = True
+        out = binarize_mask(m)
+        self.assertEqual(out.shape, (3, 3))
+        self.assertTrue(out[2, 2])
+
+    def test_centroid_vs_bbox_point_mode(self):
+        # An L-shape: its barycentre and its bbox centre are deliberately apart.
+        m = np.zeros((10, 10), dtype=bool)
+        m[0:8, 0:2] = True
+        m[6:8, 0:8] = True
+        c = mask_to_observation(m, 1, 0.9, "centroid")
+        b = mask_to_observation(m, 1, 0.9, "bbox")
+        self.assertEqual(b.bbox, (0, 0, 8, 8))
+        self.assertEqual((b.cx, b.cy), (4, 4))
+        self.assertNotEqual((c.cx, c.cy), (b.cx, b.cy))
+        self.assertEqual(c.area, int(m.sum()))
+
+    def test_empty_mask_is_no_observation(self):
+        self.assertIsNone(
+            mask_to_observation(np.zeros((5, 5), bool), 0, 1.0))
+
+
+# ── Output normalisation ───────────────────────────────────────────────────────
+
+class TestNormalizeOutputs(unittest.TestCase):
+    def setUp(self):
+        self.cfg = Sam3Config()
+        self.shape = (120, 160)
+
+    def _run(self, layout, dtype="bool"):
+        fp = FakePredictor(output_layout=layout, mask_dtype=dtype)
+        raw = fp._outputs({0: (40.0, 30.0), 1: (80.0, 60.0)}, 0)
+        return normalize_frame_outputs(raw, self.shape, self.cfg)
+
+    def test_all_layouts_agree(self):
+        ref = self._run("arrays")
+        self.assertEqual(sorted(ref), [0, 1])
+        for layout in ("mapping", "mapping_dict", "attrs"):
+            got = self._run(layout)
+            self.assertEqual(sorted(got), [0, 1], layout)
+            for oid in ref:
+                self.assertEqual((got[oid].cx, got[oid].cy),
+                                 (ref[oid].cx, ref[oid].cy), layout)
+
+    def test_all_mask_dtypes_agree(self):
+        ref = self._run("arrays", "bool")
+        for dtype in ("logits", "probs"):
+            got = self._run("arrays", dtype)
+            for oid in ref:
+                self.assertEqual((got[oid].cx, got[oid].cy),
+                                 (ref[oid].cx, ref[oid].cy), dtype)
+
+    def test_masks_at_other_resolution_are_resized(self):
+        fp = FakePredictor(mask_scale=0.5)
+        raw = fp._outputs({0: (40.0, 30.0)}, 0)
+        got = normalize_frame_outputs(raw, self.shape, self.cfg)
+        # Half-resolution mask must land back at full-frame coordinates.
+        self.assertAlmostEqual(got[0].cx, 40, delta=2)
+        self.assertAlmostEqual(got[0].cy, 30, delta=2)
+
+    def test_none_and_empty(self):
+        self.assertEqual(normalize_frame_outputs(None, self.shape, self.cfg), {})
+        self.assertEqual(
+            normalize_frame_outputs(
+                {"pred_masks": np.zeros((0, 1, 1)), "obj_ids": [], "scores": []},
+                self.shape, self.cfg), {})
+
+    def test_min_area_and_min_score_filters(self):
+        fp = FakePredictor(radius=2)
+        raw = fp._outputs({0: (40.0, 30.0)}, 0)
+        strict = Sam3Config(min_area=10_000)
+        self.assertEqual(normalize_frame_outputs(raw, self.shape, strict), {})
+        strict = Sam3Config(min_score=0.99)
+        self.assertEqual(normalize_frame_outputs(raw, self.shape, strict), {})
+
+    def test_mask_id_count_mismatch_is_loud(self):
+        raw = {"pred_masks": np.ones((3, 1, 4, 4), dtype=bool), "obj_ids": [0, 1]}
+        with self.assertRaises(ValueError):
+            normalize_frame_outputs(raw, (4, 4), self.cfg)
+
+    def test_unrecognised_output_raises(self):
+        with self.assertRaises(TypeError):
+            normalize_frame_outputs({"nothing": 1}, self.shape, self.cfg)
+
+
+# ── Frame window ───────────────────────────────────────────────────────────────
+
+class TestFrameWindow(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.video = Path(self.tmp.name) / "clip.mp4"
+        make_video(self.video, 40)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_index_mapping_is_inverse(self):
+        w = FrameWindow(str(self.video), 520, 1200)
+        self.assertEqual(w.to_absolute(0), 520)
+        self.assertEqual(w.to_local(520), 0)
+        for i in (0, 1, 137, 680):
+            self.assertEqual(w.to_local(w.to_absolute(i)), i)
+
+    def test_extract_writes_only_the_window(self):
+        with FrameWindow(str(self.video), 10, 19) as w:
+            d = w.extract()
+            self.assertEqual(w.n_frames, 10)
+            self.assertEqual(len(list(d.glob("*.jpg"))), 10)
+            self.assertEqual(w.to_absolute(w.n_frames - 1), 19)
+            self.assertEqual((w.width, w.height), (160, 120))
+
+    def test_extract_clamps_past_the_end(self):
+        with FrameWindow(str(self.video), 35, 999) as w:
+            w.extract()
+            self.assertEqual(w.n_frames, 5)
+
+    def test_extracted_frames_are_the_right_ones(self):
+        # The load-bearing property of the whole backend: the frame stored under
+        # absolute index N really is source frame N.  If extraction is off by
+        # even one, every trail is silently offset against the footage.
+        with FrameWindow(str(self.video), 12, 20) as w:
+            w.extract()
+            for abs_idx in (12, 15, 20):
+                img = w.read_frame(abs_idx)
+                self.assertIsNotNone(img, abs_idx)
+                self.assertEqual(frame_index_of(img), abs_idx)
+
+    def test_extraction_matches_a_sequential_read_of_the_source(self):
+        # render.py consumes the source sequentially from frame 0, so that read
+        # order is the reference the extractor has to agree with.
+        cap = cv2.VideoCapture(str(self.video))
+        expected = []
+        for i in range(25):
+            ok, f = cap.read()
+            if not ok:
+                break
+            if i >= 12:
+                expected.append(frame_index_of(f))
+        cap.release()
+
+        with FrameWindow(str(self.video), 12, 24) as w:
+            w.extract()
+            got = [frame_index_of(w.read_frame(w.to_absolute(i)))
+                   for i in range(w.n_frames)]
+        self.assertEqual(got, expected)
+
+    def test_empty_window_rejected(self):
+        with FrameWindow(str(self.video), 20, 10) as w:
+            with self.assertRaises(ValueError):
+                w.extract()
+
+    def test_cleanup_removes_temp_dir(self):
+        w = FrameWindow(str(self.video), 0, 4)
+        d = w.extract()
+        self.assertTrue(d.exists())
+        w.cleanup()
+        self.assertFalse(d.exists())
+
+
+# ── Tracking with the fake predictor ───────────────────────────────────────────
+
+class TestTrackWindow(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.video = Path(self.tmp.name) / "clip.mp4"
+        make_video(self.video, 60)
+        self.cfg = Sam3Config()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _window(self, start=20, end=39):
+        w = FrameWindow(str(self.video), start, end)
+        w.extract()
+        return w
+
+    def test_results_are_keyed_by_absolute_frame(self):
+        fp = FakePredictor()
+        with self._window(20, 39) as w:
+            res = track_window(
+                w, self.cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                progress=False)
+        # The regression this guards: keys must be 20..39, not 0..19.
+        self.assertEqual(min(res), 20)
+        self.assertEqual(max(res), 39)
+        self.assertEqual(len(res), 20)
+
+    def test_trail_follows_the_known_motion(self):
+        fp = FakePredictor(velocity=(2.0, 1.0))
+        with self._window(20, 39) as w:
+            res = track_window(
+                w, self.cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                progress=False)
+        trails = observations_to_trails(res, {0: "cf1"})
+        x0, y0 = trails["cf1"][20]
+        x5, y5 = trails["cf1"][25]
+        self.assertAlmostEqual(x5 - x0, 10, delta=1)   # 2 px/frame × 5
+        self.assertAlmostEqual(y5 - y0, 5,  delta=1)
+
+    def test_box_prompt_keyword_is_probed(self):
+        # This build only accepts 'bbox'; the backend must find it by probing.
+        fp = FakePredictor(box_key="bbox")
+        with self._window(20, 29) as w:
+            res = track_window(
+                w, self.cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                progress=False)
+        self.assertTrue(any(r["type"] == "add_prompt" and "bbox" in r
+                            for r in fp.requests))
+        self.assertEqual(len(res), 10)
+
+    def test_no_box_keyword_accepted_raises_clearly(self):
+        fp = FakePredictor(box_key="totally_unknown_key")
+        with self._window(20, 29) as w:
+            with self.assertRaises(RuntimeError) as ctx:
+                track_window(w, self.cfg, predictor=fp,
+                             prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                             progress=False)
+        self.assertIn("--box-key", str(ctx.exception))
+
+    def test_point_prompt_path(self):
+        fp = FakePredictor()
+        with self._window(20, 29) as w:
+            res = track_window(
+                w, self.cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                prompt_shape="point", progress=False)
+        self.assertTrue(any("points" in r for r in fp.requests))
+        self.assertEqual(len(res), 10)
+
+    def test_normalized_coords_are_sent_in_unit_range(self):
+        fp = FakePredictor()
+        cfg = Sam3Config(normalize_coords=True)
+        with self._window(20, 29) as w:
+            track_window(w, cfg, predictor=fp,
+                         prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                         progress=False)
+        box = next(np.asarray(r["box"]).reshape(-1)
+                   for r in fp.requests if "box" in r)
+        self.assertTrue(all(0.0 <= v <= 1.0 for v in box.tolist()), box)
+
+    def test_text_prompt_discovers_objects(self):
+        fp = FakePredictor()
+        with self._window(20, 39) as w:
+            res = track_window(w, self.cfg, predictor=fp, text="drone",
+                               progress=False)
+        names = discover_id_names(res)
+        self.assertEqual(names, {0: "obj0", 1: "obj1"})
+        self.assertTrue(any(r.get("text") == "drone" for r in fp.requests))
+
+    def test_discovered_names_can_be_overridden(self):
+        fp = FakePredictor()
+        with self._window(20, 39) as w:
+            res = track_window(w, self.cfg, predictor=fp, text="drone",
+                               progress=False)
+        self.assertEqual(discover_id_names(res, name_map={1: "cf2"}),
+                         {0: "obj0", 1: "cf2"})
+
+    def test_dropouts_leave_holes_not_wrong_points(self):
+        fp = FakePredictor(drop_frames={3: {0}, 4: {0}, 5: {0}})
+        with self._window(20, 39) as w:
+            res = track_window(
+                w, self.cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                progress=False)
+        trails = observations_to_trails(res, {0: "cf1"})
+        for missing in (23, 24, 25):
+            self.assertNotIn(missing, trails["cf1"])
+        self.assertIn(26, trails["cf1"])
+
+    def test_mask_sink_receives_masks_and_frees_them(self):
+        # Holding raw masks would be ~2 MB each at 1080p; the sink exists so
+        # they are compressed on arrival and dropped from the Observation.
+        seen: list[tuple[int, int, tuple]] = []
+        cfg = Sam3Config(
+            keep_masks=True,
+            mask_sink=lambda f, oid, m: seen.append((f, oid, m.shape)),
+        )
+        with self._window(20, 29) as w:
+            res = track_window(
+                w, cfg, predictor=FakePredictor(),
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                progress=False)
+        self.assertEqual(len(seen), 10)
+        self.assertEqual(seen[0][0], 20)                  # absolute frame index
+        self.assertEqual(seen[0][2], (120, 160))          # full-frame shape
+        for per_obj in res.values():
+            for obs in per_obj.values():
+                self.assertIsNone(obs.mask)
+
+    def test_masks_are_not_decoded_without_keep_masks(self):
+        cfg = Sam3Config(keep_masks=False)
+        with self._window(20, 29) as w:
+            res = track_window(
+                w, cfg, predictor=FakePredictor(),
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                progress=False)
+        self.assertTrue(all(o.mask is None
+                            for p in res.values() for o in p.values()))
+
+    def test_prompts_and_text_are_mutually_exclusive(self):
+        with self._window(20, 29) as w:
+            with self.assertRaises(ValueError):
+                track_window(w, self.cfg, predictor=FakePredictor(), progress=False)
+            with self.assertRaises(ValueError):
+                track_window(w, self.cfg, predictor=FakePredictor(), text="a",
+                             prompts=[PromptSpec("x", 0, box=(1, 1, 2, 2))],
+                             progress=False)
+
+    def test_caller_owned_predictor_is_not_shut_down(self):
+        fp = FakePredictor()
+        with self._window(20, 29) as w:
+            track_window(w, self.cfg, predictor=fp,
+                         prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                         progress=False)
+        self.assertEqual(fp.shutdown_calls, 0)
+
+    def test_session_is_closed(self):
+        fp = FakePredictor()
+        with self._window(20, 29) as w:
+            track_window(w, self.cfg, predictor=fp,
+                         prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))],
+                         progress=False)
+        self.assertEqual(fp.sessions, {})
+
+
+class TestChunkedTracking(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.video = Path(self.tmp.name) / "clip.mp4"
+        make_video(self.video, 80)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_chunking_covers_every_frame_and_keeps_ids(self):
+        fp = FakePredictor()
+        cfg = Sam3Config(chunk_size=10, chunk_overlap=2)
+        w = FrameWindow(str(self.video), 20, 69)
+        w.extract()
+        try:
+            res = track_window_chunked(
+                w, cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10)),
+                         PromptSpec("cf2", 1, box=(80, 60, 10, 10))])
+        finally:
+            w.cleanup()
+        self.assertEqual(sorted(res), list(range(20, 70)))
+        for f in range(20, 70):
+            self.assertEqual(sorted(res[f]), [0, 1], f)
+        self.assertGreater(len(fp.sessions), -1)   # all sessions closed
+        self.assertEqual(fp.sessions, {})
+
+    def test_overlap_at_least_chunk_size_still_terminates(self):
+        # --reprompt-every 5 with the default --chunk-overlap 8 used to make the
+        # window start go backwards, looping forever.
+        fp = FakePredictor()
+        cfg = Sam3Config(chunk_size=5, chunk_overlap=8)
+        w = FrameWindow(str(self.video), 20, 39)
+        w.extract()
+        try:
+            res = track_window_chunked(
+                w, cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))])
+        finally:
+            w.cleanup()
+        self.assertEqual(sorted(res), list(range(20, 40)))
+
+    def test_chunk_size_zero_is_a_single_pass(self):
+        fp = FakePredictor()
+        cfg = Sam3Config(chunk_size=0)
+        w = FrameWindow(str(self.video), 20, 39)
+        w.extract()
+        try:
+            res = track_window_chunked(
+                w, cfg, predictor=fp,
+                prompts=[PromptSpec("cf1", 0, box=(40, 30, 10, 10))])
+        finally:
+            w.cleanup()
+        starts = [r for r in fp.requests if r["type"] == "start_session"]
+        self.assertEqual(len(starts), 1)
+        self.assertEqual(sorted(res), list(range(20, 40)))
+
+
+# ── Trails, palette, gap fill ──────────────────────────────────────────────────
+
+class TestTrailAssembly(unittest.TestCase):
+    def test_unknown_ids_are_ignored(self):
+        res = {5: {0: Observation(0, 1, 2, (0, 0, 1, 1), 1, 1.0),
+                   9: Observation(9, 3, 4, (0, 0, 1, 1), 1, 1.0)}}
+        self.assertEqual(observations_to_trails(res, {0: "cf1"}),
+                         {"cf1": {5: (1, 2)}})
+
+    def test_named_agent_with_no_observations_still_present(self):
+        self.assertEqual(observations_to_trails({}, {0: "cf1"}), {"cf1": {}})
+
+    def test_discover_names_ordered_by_first_appearance(self):
+        o = lambda i: Observation(i, 0, 0, (0, 0, 1, 1), 1, 1.0)   # noqa: E731
+        res = {10: {7: o(7)}, 11: {7: o(7), 3: o(3)}}
+        self.assertEqual(discover_id_names(res), {7: "obj0", 3: "obj1"})
+
+    def test_palette_covers_unknown_names(self):
+        # render.py does trail_color[name] unguarded — a miss is a KeyError.
+        pal = build_palette(["cf1", "obj0", "obj1"], {"cf1": (0, 0, 255)})
+        self.assertEqual(pal["cf1"], (0, 0, 255))
+        self.assertEqual(len(pal), 3)
+        self.assertNotEqual(pal["obj0"], pal["obj1"])
+
+    def test_gap_fill_interpolates_without_detections(self):
+        trails = {"cf1": {0: (0, 0), 10: (100, 50)}}
+        filled = fill_gaps_bidirectional(trails, {}, min_gap_frames=5)
+        self.assertEqual(sorted(filled["cf1"]), list(range(11)))
+        self.assertEqual(filled["cf1"][5], (50, 25))
+
+    def test_gap_fill_leaves_short_gaps_alone(self):
+        trails = {"cf1": {0: (0, 0), 3: (30, 0)}}
+        filled = fill_gaps_bidirectional(trails, {}, min_gap_frames=5)
+        self.assertEqual(sorted(filled["cf1"]), [0, 3])
+
+    def test_gap_fill_handles_empty_trail(self):
+        self.assertEqual(fill_gaps_bidirectional({"cf1": {}}, {}), {"cf1": {}})
+
+
+# ── Tracking JSON contract ─────────────────────────────────────────────────────
+
+class TestTrackingJsonContract(unittest.TestCase):
+    REQUIRED = {
+        "video_in", "fps", "total_frames", "width", "height", "start_frame",
+        "end_frame", "trail_start_sec", "trail_end_sec", "trail_color",
+        "trail_thickness", "alpha", "trail_window", "smooth_trails", "trails",
+    }
+
+    def _build(self, **kw):
+        base = dict(
+            video_in="input/x.mp4", fps=59.94, total_frames=1323, width=1920,
+            height=1080, start_frame=520, end_frame=1200, trail_start_sec=2,
+            trail_end_sec=2, trail_color={"cf1": (0, 0, 255)}, trail_thickness=3,
+            alpha=0.6, trail_window=200, smooth_trails=True,
+            trails={"cf1": {521: (10, 20), 520: (5, 6)}},
+        )
+        base.update(kw)
+        return build_tracking_data(**base)
+
+    def test_has_every_key_render_reads(self):
+        self.assertTrue(self.REQUIRED.issubset(self._build()))
+
+    def test_frame_keys_are_strings_and_sorted(self):
+        d = self._build()
+        self.assertEqual(list(d["trails"]["cf1"]), ["520", "521"])
+        self.assertEqual(d["trails"]["cf1"]["520"], [5, 6])
+
+    def test_matches_the_committed_reference_output(self):
+        ref_path = ROOT / "output" / "crazyflo_path_tracking.json"
+        if not ref_path.exists():
+            self.skipTest("reference tracking JSON not in the checkout")
+        ref = json.loads(ref_path.read_text())
+        rebuilt = build_tracking_data(
+            video_in=ref["video_in"], fps=ref["fps"],
+            total_frames=ref["total_frames"], width=ref["width"],
+            height=ref["height"], start_frame=ref["start_frame"],
+            end_frame=ref["end_frame"], trail_start_sec=ref["trail_start_sec"],
+            trail_end_sec=ref["trail_end_sec"],
+            trail_color={k: tuple(v) for k, v in ref["trail_color"].items()},
+            trail_thickness=ref["trail_thickness"], alpha=ref["alpha"],
+            trail_window=ref["trail_window"], smooth_trails=ref["smooth_trails"],
+            trails={n: {int(f): tuple(p) for f, p in fd.items()}
+                    for n, fd in ref["trails"].items()},
+        )
+        self.assertEqual(rebuilt, ref)
+
+    def test_extra_fields_do_not_disturb_the_contract(self):
+        d = self._build(extra={"tracker": "sam3", "sam3_stats": {}})
+        self.assertEqual(d["tracker"], "sam3")
+        self.assertTrue(self.REQUIRED.issubset(d))
+
+
+# ── Mask store ─────────────────────────────────────────────────────────────────
+
+class TestMaskStore(unittest.TestCase):
+    def test_rle_roundtrip(self):
+        rng = np.random.default_rng(7)
+        for shape in ((7, 5), (1, 1), (64, 48)):
+            for p in (0.0, 1.0, 0.02, 0.5):
+                m = rng.random(shape) < p
+                self.assertTrue(
+                    np.array_equal(decode_rle(encode_rle(m), shape), m),
+                    (shape, p))
+
+    def test_rle_starting_with_foreground(self):
+        m = np.ones((3, 3), dtype=bool)
+        m[2, 2] = False
+        self.assertTrue(np.array_equal(decode_rle(encode_rle(m), (3, 3)), m))
+
+    def test_save_load_roundtrip(self):
+        m = np.zeros((40, 60), dtype=bool)
+        m[5:15, 10:30] = True
+        s = MaskStore(40, 60)
+        s.add(100, "cf1", m)
+        s.add(101, "cf1", m)
+        with tempfile.TemporaryDirectory() as td:
+            p = s.save(Path(td) / "x_masks.npz")
+            loaded = MaskStore.load(p)
+        self.assertTrue(np.array_equal(loaded.get(100, "cf1"), m))
+        self.assertIsNone(loaded.get(999, "cf1"))
+        self.assertIsNone(loaded.get(100, "nope"))
+        self.assertEqual(loaded.names(), ["cf1"])
+        self.assertEqual(loaded.frames("cf1"), [100, 101])
+
+    def test_add_is_idempotent_per_frame_and_name(self):
+        # Chunk overlap re-emits frames; the index must not gain duplicates.
+        m = np.zeros((6, 6), dtype=bool)
+        m[1, 1] = True
+        s = MaskStore(6, 6)
+        s.add(3, "cf1", m)
+        s.add(3, "cf1", m)
+        self.assertEqual(s.frames("cf1"), [3])
+        self.assertEqual(len(s), 1)
+
+    def test_rename_rekeys_data_and_index(self):
+        m = np.zeros((6, 6), dtype=bool)
+        m[2, 2] = True
+        s = MaskStore(6, 6)
+        s.add(7, "0", m)
+        s.add(8, "1", m)
+        s.rename({"0": "cf1", "1": "cf2"})
+        self.assertEqual(sorted(s.names()), ["cf1", "cf2"])
+        self.assertTrue(np.array_equal(s.get(7, "cf1"), m))
+        self.assertIsNone(s.get(7, "0"))
+
+    def test_rename_leaves_unmapped_names_alone(self):
+        s = MaskStore(4, 4)
+        s.add(1, "keepme", np.ones((4, 4), dtype=bool))
+        s.rename({"0": "cf1"})
+        self.assertEqual(s.names(), ["keepme"])
+
+    def test_sidecar_path_convention(self):
+        self.assertEqual(sidecar_path("output/a_tracking.json").name,
+                         "a_masks.npz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_track_sam3_cli.py
+++ b/tests/test_track_sam3_cli.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# tests/test_track_sam3_cli.py
+"""End-to-end tests of track_sam3.main() with the model swapped for a fake.
+
+Covers the whole CLI path — ROI loading, prompting, propagation, quality
+report, gap fill, debug video, tracking JSON and mask sidecar — and then feeds
+the result to render.py to prove the two really do interoperate.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cv2                                                  # noqa: E402
+from fake_sam3 import FakePredictor                         # noqa: E402
+
+import render                                               # noqa: E402
+import track_sam3                                           # noqa: E402
+from maskstore import MaskStore, sidecar_path               # noqa: E402
+from test_sam3_backend import make_video                    # noqa: E402
+
+
+class CliHarness(unittest.TestCase):
+    """Temp project with a video and rois.json, and a patched predictor."""
+
+    N_FRAMES = 40
+    W, H = 160, 120
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.video = self.dir / "clip.mp4"
+        make_video(self.video, self.N_FRAMES, self.W, self.H)
+
+        self.rois = self.dir / "rois.json"
+        self.rois.write_text(json.dumps({
+            "start_frame": 10,
+            "end_frame": 29,
+            "rois": {"cf1": [35, 25, 10, 10], "cf2": [75, 55, 10, 10]},
+        }))
+        self.out = self.dir / "out" / "clip_sam3.mp4"
+        self.fake = FakePredictor(height=self.H, width=self.W)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def run_cli(self, extra: list[str] | None = None, fake=None):
+        argv = ["--video", str(self.video), "--rois", str(self.rois),
+                "--out", str(self.out)] + (extra or [])
+        args = track_sam3.parse_args(argv)
+        with mock.patch.object(track_sam3, "build_predictor",
+                               return_value=fake or self.fake):
+            track_sam3.main(args)
+        return json.loads(self.tracking_json.read_text())
+
+    @property
+    def tracking_json(self) -> Path:
+        return self.out.with_name(self.out.stem + "_tracking.json")
+
+
+class TestFromRois(CliHarness):
+    def test_writes_tracking_json_with_named_agents(self):
+        d = self.run_cli(["--no-debug-video"])
+        self.assertEqual(sorted(d["trails"]), ["cf1", "cf2"])
+        self.assertEqual(d["tracker"], "sam3")
+        self.assertEqual(d["sam3_prompt"], {"rois": ["cf1", "cf2"]})
+
+    def test_trail_frames_are_absolute_and_inside_the_window(self):
+        d = self.run_cli(["--no-debug-video"])
+        frames = sorted(int(f) for f in d["trails"]["cf1"])
+        self.assertEqual(frames[0], 10)
+        self.assertEqual(frames[-1], 29)
+        self.assertEqual(len(frames), 20)
+
+    def test_video_metadata_is_the_full_source_not_the_window(self):
+        # render.py iterates range(total_frames) over the ORIGINAL video, so
+        # these must describe the source, not the extracted sub-range.
+        d = self.run_cli(["--no-debug-video"])
+        self.assertEqual(d["total_frames"], self.N_FRAMES)
+        self.assertEqual((d["width"], d["height"]), (self.W, self.H))
+        self.assertEqual((d["start_frame"], d["end_frame"]), (10, 29))
+
+    def test_every_agent_has_a_colour(self):
+        d = self.run_cli(["--no-debug-video"])
+        for name in d["trails"]:
+            self.assertIn(name, d["trail_color"])
+
+    def test_quality_stats_recorded(self):
+        d = self.run_cli(["--no-debug-video"])
+        self.assertEqual(d["sam3_stats"]["cf1"]["coverage"], 1.0)
+        self.assertEqual(d["sam3_stats"]["cf1"]["longest_gap"], 0)
+        self.assertGreater(d["sam3_stats"]["cf1"]["area_median"], 0)
+
+    def test_agents_subset(self):
+        d = self.run_cli(["--no-debug-video", "--agents", "cf1"])
+        self.assertEqual(sorted(d["trails"]), ["cf1"])
+
+    def test_frame_range_override(self):
+        d = self.run_cli(["--no-debug-video", "--start-frame", "12",
+                          "--end-frame", "17"])
+        frames = sorted(int(f) for f in d["trails"]["cf1"])
+        self.assertEqual((frames[0], frames[-1]), (12, 17))
+
+    def test_debug_video_is_written(self):
+        self.run_cli()
+        dbg = self.out.with_name(self.out.stem + "_debug.mp4")
+        self.assertTrue(dbg.exists())
+        cap = cv2.VideoCapture(str(dbg))
+        self.assertGreater(int(cap.get(cv2.CAP_PROP_FRAME_COUNT)), 0)
+        cap.release()
+
+    def test_point_prompt_shape(self):
+        d = self.run_cli(["--no-debug-video", "--prompt-shape", "point"])
+        self.assertTrue(any("points" in r for r in self.fake.requests))
+        self.assertEqual(sorted(d["trails"]), ["cf1", "cf2"])
+
+    def test_reprompt_every_chunks_the_run(self):
+        d = self.run_cli(["--no-debug-video", "--reprompt-every", "5"])
+        starts = [r for r in self.fake.requests if r["type"] == "start_session"]
+        self.assertGreater(len(starts), 1)
+        self.assertEqual(len(d["trails"]["cf1"]), 20)
+
+
+class TestGapFill(CliHarness):
+    def test_dropouts_are_interpolated_by_default(self):
+        fake = FakePredictor(height=self.H, width=self.W,
+                             drop_frames={i: {0} for i in range(4, 12)})
+        d = self.run_cli(["--no-debug-video"], fake=fake)
+        frames = sorted(int(f) for f in d["trails"]["cf1"])
+        self.assertEqual(frames, list(range(10, 30)))
+        self.assertLess(d["sam3_stats"]["cf1"]["coverage"], 1.0)
+        self.assertEqual(d["sam3_stats"]["cf1"]["longest_gap"], 8)
+
+    def test_no_gap_fill_leaves_the_hole(self):
+        fake = FakePredictor(height=self.H, width=self.W,
+                             drop_frames={i: {0} for i in range(4, 12)})
+        d = self.run_cli(["--no-debug-video", "--no-gap-fill"], fake=fake)
+        frames = sorted(int(f) for f in d["trails"]["cf1"])
+        self.assertNotIn(15, frames)
+        self.assertEqual(len(frames), 12)
+
+
+class TestTextMode(CliHarness):
+    def test_discovered_objects_get_default_names(self):
+        d = self.run_cli(["--no-debug-video", "--text", "drone"])
+        self.assertEqual(sorted(d["trails"]), ["obj0", "obj1"])
+        self.assertEqual(d["sam3_prompt"], {"text": "drone"})
+
+    def test_names_can_be_mapped(self):
+        d = self.run_cli(["--no-debug-video", "--text", "drone",
+                          "--name", "0=cf1", "--name", "1=cf2"])
+        self.assertEqual(sorted(d["trails"]), ["cf1", "cf2"])
+        # Mapped names must pick up the project palette, not a fallback colour.
+        self.assertEqual(d["trail_color"]["cf1"], [0, 0, 255])
+
+    def test_discovered_names_all_get_distinct_colours(self):
+        d = self.run_cli(["--no-debug-video", "--text", "drone"])
+        cols = [tuple(c) for c in d["trail_color"].values()]
+        self.assertEqual(len(cols), len(set(cols)))
+
+
+class TestMasksAndRender(CliHarness):
+    def test_mask_sidecar_written_and_loadable(self):
+        self.run_cli(["--no-debug-video", "--save-masks"])
+        p = sidecar_path(self.tracking_json)
+        self.assertTrue(p.exists())
+        store = MaskStore.load(p)
+        self.assertEqual(sorted(store.names()), ["cf1", "cf2"])
+        m = store.get(10, "cf1")
+        self.assertEqual(m.shape, (self.H, self.W))
+        self.assertTrue(m.any())
+
+    def test_render_consumes_the_output(self):
+        self.run_cli(["--no-debug-video", "--save-masks"])
+        render.render(str(self.tracking_json), mask_mode="off")
+        for suffix in ("_persistent.mp4", "_transient.mp4"):
+            p = self.out.parent / ("clip_sam3" + suffix)
+            self.assertTrue(p.exists(), p)
+
+    def test_render_mask_modes_run(self):
+        self.run_cli(["--no-debug-video", "--save-masks"])
+        for mode in ("occlude", "glow"):
+            render.render(str(self.tracking_json), mask_mode=mode)
+            p = self.out.parent / "clip_sam3_transient.mp4"
+            self.assertTrue(p.exists())
+
+    def test_missing_sidecar_falls_back_instead_of_crashing(self):
+        self.run_cli(["--no-debug-video"])          # no --save-masks
+        render.render(str(self.tracking_json), mask_mode="glow")
+        self.assertTrue((self.out.parent / "clip_sam3_persistent.mp4").exists())
+
+
+class TestCompositeMasks(unittest.TestCase):
+    def test_object_pixels_are_restored_over_the_trail(self):
+        base = np.full((20, 20, 3), 30, dtype=np.uint8)
+        blended = np.full((20, 20, 3), 200, dtype=np.uint8)   # trail everywhere
+        m = np.zeros((20, 20), dtype=bool)
+        m[5:10, 5:10] = True
+        out = render.composite_masks(base, blended, {"cf1": m},
+                                     {"cf1": (0, 0, 255)}, "occlude")
+        self.assertTrue((out[5:10, 5:10] == 30).all())    # object shows through
+        self.assertTrue((out[0, 0] == 200).all())         # trail survives
+
+    def test_off_mode_is_a_passthrough(self):
+        base = np.zeros((8, 8, 3), np.uint8)
+        blended = np.full((8, 8, 3), 99, np.uint8)
+        m = np.ones((8, 8), dtype=bool)
+        out = render.composite_masks(base, blended, {"a": m}, {}, "off")
+        self.assertTrue((out == 99).all())
+
+
+class TestHybridBorrow(CliHarness):
+    def test_borrowed_agent_comes_from_the_other_tracker(self):
+        donor = self.dir / "donor_tracking.json"
+        donor.write_text(json.dumps({
+            "trails": {"cf2": {str(f): [f, 99] for f in range(10, 30)}}}))
+        d = self.run_cli(["--no-debug-video", "--borrow-agents", "cf2",
+                          "--borrow-from", str(donor)])
+        self.assertEqual(sorted(d["trails"]), ["cf1", "cf2"])
+        self.assertEqual(d["trails"]["cf2"]["15"], [15, 99])
+        # The borrowed agent must not have been prompted into SAM 3.
+        self.assertEqual(d["sam3_prompt"], {"rois": ["cf1"]})
+
+    def test_unknown_borrowed_agent_is_an_error(self):
+        donor = self.dir / "donor_tracking.json"
+        donor.write_text(json.dumps({"trails": {"other": {}}}))
+        with self.assertRaises(KeyError):
+            self.run_cli(["--no-debug-video", "--borrow-agents", "cf2",
+                          "--borrow-from", str(donor)])
+
+    def test_borrow_without_source_exits(self):
+        with self.assertRaises(SystemExit):
+            self.run_cli(["--no-debug-video", "--borrow-agents", "cf2"])
+
+
+class TestArgValidation(CliHarness):
+    def test_unknown_agent_exits(self):
+        with self.assertRaises(SystemExit):
+            self.run_cli(["--agents", "nope"])
+
+    def test_bad_name_mapping_exits(self):
+        with self.assertRaises(SystemExit):
+            self.run_cli(["--text", "drone", "--name", "cf1"])
+
+    def test_zoom_on_unknown_agent_exits(self):
+        with self.assertRaises(SystemExit):
+            self.run_cli(["--no-debug-video", "--zoom-agents", "nope"])
+
+
+class TestZoomPass(CliHarness):
+    def test_zoom_results_land_in_full_frame_coordinates(self):
+        d = self.run_cli(["--no-debug-video", "--zoom-agents", "cf1",
+                          "--zoom-crop", "80", "--zoom-upscale", "2",
+                          "--zoom-segment", "10"])
+        pts = [tuple(p) for p in d["trails"]["cf1"].values()]
+        self.assertTrue(pts)
+        for x, y in pts:
+            self.assertTrue(0 <= x < self.W, (x, y))
+            self.assertTrue(0 <= y < self.H, (x, y))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a complete SAM 3 (Segment Anything Model 3) video tracking pipeline as an alternative to the existing background-subtraction-based tracker. Both trackers emit identical `*_tracking.json` output, allowing them to be swapped interchangeably while sharing all downstream rendering and processing code.

## Key Changes

- **New SAM 3 backend module** (`src/sam3_backend.py`): 
  - Wraps Meta's `Sam3VideoPredictor` session API
  - Reduces per-frame mask outputs to (frame_index → point) form consumed by render pipeline
  - Handles frame window extraction with precise index mapping (critical for synchronization with source video)
  - Implements mask-to-point reduction (centroid or bbox modes) and filtering (min score, min area)
  - Supports chunked processing for long videos with configurable overlap
  - Probes upstream API at runtime rather than hard-coding assumptions about keyword names and output shapes
  - Avoids importing torch/sam3 at module scope so rest of pipeline remains GPU-independent

- **New CLI tracker** (`src/track_sam3.py`):
  - Drop-in alternative to `track.py` with identical output contract
  - Supports two prompting modes: ROI boxes (like `track.py`) or text prompts for detector-driven tracking
  - Generates quality reports (coverage, score stats, area anomalies)
  - Writes debug video with mask tints, bboxes, labels and trails
  - Optionally stores masks in compressed RLE format via sidecar file

- **Shared trail utilities** (`src/trails.py`):
  - Extracted common geometry, smoothing, gap-fill and JSON I/O from `track.py`
  - Both trackers now use identical trail processing pipeline
  - Implements bidirectional gap-fill using corridor-based detection recovery

- **Mask storage** (`src/maskstore.py`):
  - COCO-style run-length encoding for efficient mask sidecar storage
  - Reduces ~5.6 GB of raw 1080p masks to low megabytes for typical tracking runs
  - Enables mask-aware rendering modes (occlude, glow) in `render.py`

- **Enhanced render pipeline** (`src/render.py`):
  - Added mask-aware rendering modes: `occlude` (trails behind objects) and `glow` (silhouette halo)
  - Loads optional mask sidecar when available
  - Maintains backward compatibility (defaults to off when no masks present)

- **Preflight checker** (`src/sam3_preflight.py`):
  - Validates Python version, torch, CUDA, SAM 3 package and checkpoint availability
  - Fails fast with specific error messages before expensive frame extraction

- **Comprehensive test suite**:
  - `tests/fake_sam3.py`: Mock predictor implementing full request/response protocol for testing without GPU
  - `tests/test_sam3_backend.py`: 695 lines covering mask reduction, output normalization, frame window indexing, chunking, trail assembly
  - `tests/test_track_sam3_cli.py`: End-to-end CLI tests with fake predictor, validates interoperability with `render.py`

- **Refactored `track.py`**:
  - Extracted shared helpers to `trails.py` (box_center, blend_trail, safe_append, gap-fill)
  - Maintains identical behavior while reducing duplication

## Notable Implementation Details

- **Frame indexing**: Absolute frame indices are preserved throughout the pipeline via `FrameWindow.to_absolute/to_local` mapping. This is critical because `render.py` walks the original video sequentially from frame 0, so any off-by-one error silently desynchronizes all trails.

- **API robustness**: Rather than hard-coding SAM 3 API details, the backend probes at runtime for box-prompt keywords and output shapes, with loud descriptive errors if unrecognized layouts are encountered.

- **GPU independence**: No torch/sam3 imports at module scope, allowing the entire pipeline (including tests) to run on machines without CUDA, with the

https://claude.ai/code/session_01HTTAaunh2KQN2DtpVaiNkw