### PR TITLE
Refactor stairs pipeline into two-stage GPU/CPU split

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,381 +1,213 @@
 # Comet
 
-Motion-trail visualisation tool for tracking multiple objects in video — including well-defined objects (e.g. drones, vehicles, animals) and harder-to-see ones (e.g. a small payload). Uses background subtraction + Hungarian assignment to maintain object identities across frames, then renders clean trail videos.
+Track and segment things in video, and render what you find.
 
-It also does **segmentation of static structure** — stairs, doorways, ramps — from robot recordings: see [Segmenting static structure](#segmenting-static-structure-stairs-doorways-ramps), which reads ROS 2 mcap bags directly and has a small desktop GUI.
+Two jobs:
 
-[debug video](https://github.com/user-attachments/assets/a0e2a55d-9e8b-4190-9f15-e77fb74a519f)
+- **Motion trails** — follow moving objects (drones, vehicles, animals) and draw their paths.
+- **Static structure** — segment stairs, doorways or ramps from robot recordings and measure their orientation.
 
-[transient trails](https://github.com/user-attachments/assets/e33fe741-0fd7-465e-98d2-c9d5fde95972)
+Reads plain video, photos, and ROS 2 mcap bags. Runs from the command line or a small desktop GUI.
 
+[debug video](https://github.com/user-attachments/assets/a0e2a55d-9e8b-4190-9f15-e77fb74a519f) ·
+[transient trails](https://github.com/user-attachments/assets/e33fe741-0fd7-465e-98d2-c9d5fde95972) ·
 [persistent trails](https://github.com/user-attachments/assets/be91b6bf-33b3-4584-b761-8da9fd4e519d)
 
-## Workflow
-
-Two interchangeable trackers write the same `*_tracking.json`, so everything
-downstream is shared:
-
-```
-input video
-    │
-    ▼
-pick.py          ← interactively select objects and frame range
-    │ rois.json
-    ├─────────────────────────┐
-    ▼                         ▼
-track.py                  track_sam3.py    ← SAM 3 (GPU); text prompts optional
-background subtraction    promptable segmentation + tracking
-    │                         │
-    └──────────┬──────────────┘
-               │ *_tracking.json + *_debug.mp4  (+ *_masks.npz from SAM 3)
-               ▼
-        render.py        ← render persistent and transient trail videos
-               │ *_persistent.mp4 + *_transient.mp4
-               ▼
-        to_webm.py       ← (optional) batch-convert output/*.mp4 → output/webm/
-```
-
-Which tracker to use:
-
-| | `track.py` | `track_sam3.py` |
-|---|---|---|
-| Hardware | any laptop | CUDA GPU |
-| Camera | must be static | may move |
-| Setup | none | SAM 3 install + gated checkpoint |
-| Selecting objects | boxes in `rois.json` | boxes **or** a text prompt |
-| Output | centroids | centroids + masks |
-| Tiny/low-contrast objects | tuned sensitive mask | may need `--zoom-agents` |
-
-## Setup
+## Install
 
 ```bash
-python -m venv venv
-source venv/bin/activate
+python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-For the SAM 3 backend only (see [SAM 3 tracking](#sam-3-tracking-track_sam3py)):
+Optional extras:
 
 ```bash
-pip install -r requirements-sam3.txt
+pip install -r requirements-mcap.txt    # read ROS 2 mcap bags
+pip install -r requirements-sam3.txt    # SAM 3 tracking (CUDA GPU)
 git clone https://github.com/facebookresearch/sam3 && pip install -e sam3
-python src/sam3_preflight.py     # verifies python/torch/CUDA/sam3/weights
+python src/sam3_preflight.py            # check the setup
 ```
 
-**Weights.** `track_sam3.py` looks for a local checkpoint in this order:
+SAM 3 weights are found at `--checkpoint`, then `$COMET_SAM3_CHECKPOINT`, then
+`~/ws/models/weights/sam3.pt`.
 
-1. `--checkpoint /path/to/sam3.pt`
-2. `$COMET_SAM3_CHECKPOINT`
-3. `~/ws/models/weights/sam3.pt`, `~/ws/models/weights/sam3.1.pt`,
-   `models/weights/sam3.pt`
+---
 
-A local file is passed straight to the builder as `checkpoint_path`, which
-skips its `load_from_HF` default — so with weights on disk you need no Hugging
-Face account at all. Only if nothing is found does SAM 3 fall back to
-downloading the gated `facebook/sam3` checkpoint, which requires
-[requesting access](https://huggingface.co/facebook/sam3) and
-`huggingface-cli login`. A `--checkpoint` or `$COMET_SAM3_CHECKPOINT` that
-points at a missing file is an error, not a silent fallback to the download.
+## Motion trails
 
-## Usage
+```
+video ──▶ pick objects ──▶ track ──▶ render
+```
 
-**1. Pick objects and frame range** — `src/pick.py`
+**1. Pick objects and frame range.** Interactively:
 
 ```bash
 python src/pick.py
 ```
 
-Opens an interactive window. Use arrow keys / `a` / `d` to scrub the video, then press Space/Enter to confirm each step:
+Arrow keys or `a`/`d` to scrub, Space/Enter to confirm each step: start frame,
+end frame, then a box around each object. Objects are named in the `AGENTS`
+list at the top of the file.
 
-1. **Start frame** — first frame of interest (objects should be in their starting positions)
-2. **End frame** — last frame of interest
-3. **Bounding boxes** — draw a box around each object to track (one at a time)
-
-Objects are defined in the `AGENTS` list at the top of `pick.py`. Each agent can represent any moving object — label them to suit your footage. The tool handles two distinct detection modes under the hood:
-
-- **High-contrast objects** (well-lit, distinct from background) — tracked with a standard foreground mask
-- **Low-contrast objects** (small, dim, or occluded) — additionally detected with a more sensitive mask restricted to the object's expected spatial band, so they don't get lost when the standard threshold misses them
-
-Saves `src/rois.json`.
-
-**2. Track** — `src/track.py`
+Or from the command line:
 
 ```bash
-python src/track.py
+python src/make_rois.py --video input/crazyflo.mp4 \
+    --start-frame 520 --end-frame 1200 \
+    --roi cf1=940,234,87,57 --roi payload=1278,546,26,34
 ```
 
-Reads `input/` video + `src/rois.json`. Builds a background model from pre-motion frames, then tracks all objects frame-by-frame. Gap periods (when an object is temporarily undetected) are filled using a bidirectional corridor search.
+`--from-json` amends an existing file; `--drop NAME` removes an object;
+`--show` prints without writing.
 
-Writes to `output/`:
-- `*_debug.mp4` — annotated video showing bounding boxes, labels, and trails
-- `*_tracking.json` — full per-frame coordinate log for all objects
-
-Pass `--no-display` to run without a GUI window (headless machines, remote boxes).
-`--video`, `--rois` and `--out` override the paths at the top of the file.
-
-### SAM 3 tracking (`track_sam3.py`)
-
-A drop-in alternative to step 2 that uses Meta's [SAM 3](https://github.com/facebookresearch/sam3)
-instead of background subtraction. It needs no background model, so it tolerates
-a moving camera and changing light, and it returns masks rather than blobs — so
-overlapping objects keep their own centroids.
+**2. Track.** Background subtraction with Hungarian assignment:
 
 ```bash
-python src/sam3_preflight.py                          # check the environment first
-python src/track_sam3.py --out output/crazyflo_sam3.mp4
-python src/render.py output/crazyflo_sam3_tracking.json
+python src/track.py                 # add --no-display to run headless
 ```
 
-Because both trackers write the same JSON, you can render each and compare them
-on the same clip.
+Builds a background model from pre-motion frames, then follows every object
+frame by frame, filling gaps with a bidirectional corridor search. Writes
+`*_debug.mp4` and `*_tracking.json`.
 
-**Choosing what to track.** Either seed from the boxes you already picked, which
-keeps your `cf1`/`cf2`/`cf3`/`payload` names:
+Or with SAM 3, which needs no background model and so tolerates a moving
+camera:
 
 ```bash
-python src/track_sam3.py --from-rois                   # default
+python src/track_sam3.py --from-rois          # keeps your object names
+python src/track_sam3.py --text "drone"       # finds them from a description
 ```
 
-…or describe the objects and let the detector find them. Discovered objects are
-named by first appearance (`obj0`, `obj1`, …) and can be renamed:
+Useful flags: `--zoom-agents payload` re-tracks a small object through an
+upscaled crop; `--borrow-agents payload --borrow-from <json>` takes one object
+from another tracker's output; `--reprompt-every N` re-anchors on long clips;
+`--save-masks` writes a mask sidecar.
+
+**3. Render.**
 
 ```bash
-python src/track_sam3.py --text "drone" --name 0=cf1 --name 1=cf2
+python src/render.py output/crazyflo_path_tracking.json
 ```
 
-**Key options**
-
-| Option | Purpose |
+| Output | |
 |---|---|
-| `--agents cf1,cf2` | track a subset of `rois.json` |
-| `--prompt-shape point` | seed with the ROI's centre point instead of its box |
-| `--point-mode bbox` | use bbox centres instead of mask barycentres |
-| `--reprompt-every N` | re-seed every N frames; also caps memory-bank VRAM on long clips |
-| `--min-score` / `--min-area` | drop weak or implausibly small detections |
-| `--zoom-agents payload` | re-track an agent through an upscaled crop (see below) |
-| `--borrow-agents payload --borrow-from <json>` | take that agent from another tracker's output |
-| `--save-masks` | write a `*_masks.npz` sidecar for mask-aware rendering |
-| `--no-gap-fill` | leave dropouts as holes instead of interpolating |
-| `--checkpoint PATH` | weights file (see [Setup](#setup) for the search order) |
-| `--gpus 0,1` | restrict which CUDA devices are used |
+| `*_persistent.mp4` | trails accumulate from start to end |
+| `*_transient.mp4` | shooting-star: bright at the head, fading along the tail |
 
-**Quality reporting.** Every run logs per-object coverage, longest dropout,
-score range and mask area, and stores them under `sam3_stats` in the tracking
-JSON. Coverage is the number to watch: gap fill will happily draw a straight
-line through a stretch where the object was never actually found, and the trail
-video alone will not show you that.
+Appearance is settable per run: `--thickness`, `--alpha`, `--trail-window`,
+`--color cf1=255,0,0`, `--smooth` / `--no-smooth`. With a mask sidecar,
+`--mask-mode occlude` draws trails behind objects and `--mask-mode glow` adds a
+silhouette halo.
 
-**Small, low-contrast objects.** A 26×34 px payload is ~0.04 % of a 1080p frame,
-which is where SAM 3 is weakest. Two fallbacks, in order of preference:
+**4. WebM** (optional):
 
 ```bash
-# 1. re-track it through a crop that is upscaled before it reaches the model
-python src/track_sam3.py --zoom-agents payload --zoom-crop 384 --zoom-upscale 3
-
-# 2. hybrid: SAM 3 for the drones, background subtraction for the payload
-python src/track.py --no-display                       # produces the donor JSON
-python src/track_sam3.py --borrow-agents payload \
-    --borrow-from output/crazyflo_path_tracking.json
+python src/to_webm.py                            # scans output/
+python src/to_webm.py clip.mp4 --bitrate 4M
 ```
 
-**Tests.** The plumbing around the model — frame-index mapping, prompt dispatch,
-output normalisation, chunking, trail assembly, mask storage — is covered by a
-fake predictor and needs no GPU:
+---
 
-```bash
-python -m unittest discover -s tests
-```
+## Static structure
 
-**3. Render trails** — `src/render.py`
-
-```bash
-python src/render.py
-```
-
-Reads the tracking JSON and produces two clean videos:
-
-| Output | Description |
-|---|---|
-| `*_persistent.mp4` | Trails accumulate from start to end |
-| `*_transient.mp4` | Shooting-star style: thick at the current position, tapering and fading over ~¼ orbit |
-
-Trail appearance (color, thickness, alpha, window length) can be overridden via the `OVERRIDES` dict at the top of the file without re-running tracking.
-
-If a `*_masks.npz` sidecar exists (written by `track_sam3.py --save-masks`), two
-extra render modes become available:
-
-```bash
-python src/render.py output/crazyflo_sam3_tracking.json --mask-mode occlude
-python src/render.py output/crazyflo_sam3_tracking.json --mask-mode glow
-```
-
-| Mode | Effect |
-|---|---|
-| `off` | default — trails drawn straight over the frame |
-| `occlude` | trails pass *behind* the objects |
-| `glow` | `occlude`, plus a coloured halo around each silhouette |
-
-Without a sidecar these fall back to `off`.
-
-**4. Convert to WebM** — `src/to_webm.py` *(optional)*
-
-```bash
-python src/to_webm.py
-```
-
-Batch-converts all `output/*.mp4` → `output/webm/*.webm` using VP9. Useful for web embedding.
-
-## Segmenting static structure (stairs, doorways, ramps)
-
-Trails are for things that move. For structure that stays put while the camera
-moves, a trail would just encode your own egomotion — so this path renders a
-**per-frame segmentation overlay** and measures the subject's **orientation**
-instead.
+For things that stay put while the camera moves. Renders a per-frame
+segmentation overlay and measures the subject's angle.
 
 ```
-mcap bags / video / photos ──▶ SAM 3 (text prompt) ──▶ masks ──┬──▶ overlay video
-                                                               └──▶ orientation JSON
+mcap bags / video / photos ──▶ SAM 3 ──▶ masks ──┬──▶ overlay video
+                                                 └──▶ orientation JSON
 ```
 
-### GUI
+**GUI:**
 
 ```bash
 python src/gui.py
 ```
 
-Pick a recording folder, press **Scan bag**, choose the camera topic, type what
-to look for (`stairs`), press **Run**. Needs Tk — `sudo apt install python3-tk`
-if the app reports it missing. Plain videos, single photos and folders of
-photos work too; those need no topic.
+Pick a recording, press **Scan bag**, choose a camera topic, type what to look
+for, press **Run**. (`sudo apt install python3-tk` if Tk is missing.)
 
-### Command line
+**Command line:**
 
 ```bash
-pip install -r requirements-mcap.txt
-
-# what cameras are in the bag?
-python src/stairs_pipeline.py --list /path/to/bags
-
-# run it
+python src/stairs_pipeline.py --list /path/to/bags       # what cameras are in there
 python src/stairs_pipeline.py /path/to/bags \
     --topic /camera/color/image_raw --prompt stairs --out output/stairs
 ```
 
-Works the same on other inputs:
+The same command takes a video, a photo, or a folder of photos — those need no
+topic:
 
 ```bash
 python src/stairs_pipeline.py clip.mp4 --prompt stairs
-python src/stairs_pipeline.py photo.jpg --prompt stairs
-python src/stairs_pipeline.py ./photos/ --prompt stairs
+python src/stairs_pipeline.py ./photos/ --prompt "door"
 ```
 
-### Running the model on a different machine
+| Output | |
+|---|---|
+| `*_overlay.mp4` | masks tinted and outlined, angle drawn and annotated |
+| `*_stairs.json` | per-frame angles, coverage, provenance, bag timestamps |
+| `*_masks.npz` | run-length mask sidecar |
+| `*_frames.mp4` | decoded frames, so the analysis can re-run on its own |
 
-Only SAM 3 needs a GPU. The pipeline splits at that boundary, so the model can
-run on the CUDA box while everything else runs wherever you like:
+### Running the model elsewhere
+
+Only SAM 3 needs a GPU, and the pipeline splits at that line:
 
 ```bash
 # on the GPU machine
-python src/stairs_pipeline.py /path/to/bags \
-    --topic /camera/color/image_raw --prompt stairs \
-    --out output/stairs --stage segment
+python src/stairs_pipeline.py /path/to/bags --topic /camera/color/image_raw \
+    --prompt stairs --out output/stairs --stage segment
 
-# copy output/stairs_{stairs.json,masks.npz,frames.mp4} across, then anywhere:
+# copy the three files across, then anywhere:
 python src/stairs_pipeline.py --stage analyse --out output/stairs
 ```
 
-Those three files are a complete handoff — the analyse stage never touches the
-bags, the model or CUDA. The masks are run-length encoded, so the bulk is just
-the frames video.
+The analyse stage reads only stage 1's output, so retuning orientation costs
+seconds rather than another pass of the model.
 
-This is worth using on a single machine too: retuning orientation costs seconds
-in the analyse stage instead of a full pass of the model.
+### Orientation
 
-**Outputs** (`--out` stem):
+`angle_deg` is the dominant edge direction in the image plane, in degrees,
+wrapped to `[0, 180)`. It comes from Hough segments inside the mask,
+length-weighted into an angle histogram. Each frame also reports a
+`confidence`: the share of edge length pointing the dominant way.
 
-| File | Contents |
+### mcap bags
+
+Bags decode with no ROS installation. A recording split across `_0.mcap`,
+`_1.mcap`, … reads as one stream ordered by message timestamp.
+`sensor_msgs/msg/Image` and `CompressedImage` are both handled, across the
+encodings RealSense emits (`rgb8`, `bgr8`, `mono8`, `mono16`, YUV, Bayer).
+Frame rate is measured from the message timestamps.
+
+---
+
+## Layout
+
+| | |
 |---|---|
-| `*_overlay.mp4` | frames with masks tinted and outlined, angle drawn and annotated |
-| `*_stairs.json` | per-frame angles, coverage, provenance, mcap timestamps |
-| `*_masks.npz` | RLE mask sidecar |
-| `*_frames.mp4` | the decoded frames, so the analyse stage can re-run standalone |
-
-### Hardware
-
-SAM 3 needs **CUDA**. The upstream package will not run on Apple Silicon — it
-calls `.cuda()` unconditionally, gates on `device.type == "cuda"`, and needs
-Triton kernels plus the `torch_generic_nms` CUDA extension
-([sam3#164](https://github.com/facebookresearch/sam3/issues/164)). `sam3_preflight.py`
-detects this and says so rather than reporting a missing GPU.
-
-Everything else — bag reading, orientation, overlay, the GUI, the test suite —
-needs no GPU and runs anywhere.
-
-### Reading mcap bags
-
-rosbag2 embeds message schemas in the file, so bags decode with **no ROS
-installation**. A recording split across `_0.mcap`, `_1.mcap`, … is read as one
-continuous stream, ordered by message timestamp rather than filename (plain
-sorting puts `_10` before `_9`). `sensor_msgs/msg/Image` and `CompressedImage`
-are both handled, across the encodings RealSense emits (`rgb8`, `bgr8`,
-`mono8`, `mono16`, YUV, Bayer).
-
-To try it without real data:
-
-```bash
-python tests/make_bag.py /tmp/fakebag --splits 3 --frames 30 --angle 25
-```
-
-### What the orientation number means
-
-`angle_deg` is the dominant edge direction **in the image plane**, in degrees,
-wrapped to `[0, 180)` because a line has no direction. It comes from Hough
-segments found inside the mask, length-weighted into an angle histogram.
-
-It is **not** the stairs' 3D orientation relative to the robot — that needs
-camera intrinsics plus either the nosing lines' vanishing point or the depth
-stream. The image-plane angle is directly useful for alignment ("is the robot
-square to the flight?") and is the input to that later 3D step.
-
-Every frame also carries a `confidence`: the share of detected edge length
-pointing the dominant way. A clean staircase reads ~1.0; competing directions
-(railings, floor tiles) pull it down, and frames with no consistent direction
-report `null` rather than a guess.
-
-**Visual odometry is not implemented.** Monocular VO needs intrinsics, feature
-tracking, essential-matrix decomposition, and still leaves scale ambiguous —
-it's a subsystem, not a flag. See the note at the end of this section if you
-want the cheap approximation.
-
-## Source layout
-
-| File | Role |
-|---|---|
-| `pick.py` | interactive ROI + frame-range picker → `rois.json` |
+| `pick.py` / `make_rois.py` | choose objects and frame range, interactively or by flag |
 | `track.py` | background-subtraction tracker |
-| `track_sam3.py` | SAM 3 tracker (CLI, both prompting modes) |
-| `sam3_backend.py` | SAM 3 session wrapper: frame windowing, prompts, masks |
-| `sam3_preflight.py` | environment check for the SAM 3 backend |
-| `trails.py` | shared smoothing, gap fill, palette and tracking-JSON contract |
+| `track_sam3.py` | SAM 3 tracker |
+| `sam3_backend.py` | SAM 3 sessions, frame windowing, masks |
+| `sam3_preflight.py` | environment check |
+| `stairs_pipeline.py` | recordings → masks → overlay + orientation |
+| `stair_orientation.py` | dominant edge angle from a mask |
+| `mcap_source.py` | ROS 2 bag reading |
+| `media.py` | video / photos / bags → one video |
+| `trails.py` | smoothing, gap fill, tracking-JSON format |
 | `maskstore.py` | run-length mask sidecar |
 | `render.py` | trail videos |
 | `to_webm.py` | MP4 → WebM |
-| `gui.py` | desktop front end for the static-structure path |
-| `stairs_pipeline.py` | mcap/video/photos → masks → overlay + orientation |
-| `mcap_source.py` | ROS 2 mcap reading, no ROS install required |
-| `media.py` | normalises video / photo / photo folder / bags into one video |
-| `stair_orientation.py` | dominant edge angle from a mask |
+| `gui.py` | desktop front end |
 
-## Configuration
+## Tests
 
-Key constants in `src/track.py`:
+```bash
+python -m unittest discover -s tests
+```
 
-| Constant | Default | Description |
-|---|---|---|
-| `VIDEO_IN` | `input/crazyflo.mp4` | Input video path |
-| `VIDEO_OUT` | `output/crazyflo_path.mp4` | Output path stem |
-| `AGENTS` | `["cf1","cf2","cf3","payload"]` | Object names (edit in `pick.py` too) |
-| `TRAIL_COLOR` | per-agent BGR | Colors for each object |
-| `MAX_ASSIGN_DIST` | `260` | Max px distance for Hungarian assignment |
-| `AGENT_Y_CLAMP` | `{"payload": 120}` | Hard vertical gate for low-contrast objects |
-| `CLAMP_WHEN_LOST` | `{"payload"}` | Agents that fall back to nearest blob when unmatched |
+204 tests, no GPU required. `python tests/make_bag.py /tmp/fakebag --angle 25`
+writes a synthetic RealSense recording to try the pipeline against.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,28 @@ python src/stairs_pipeline.py photo.jpg --prompt stairs
 python src/stairs_pipeline.py ./photos/ --prompt stairs
 ```
 
+### Running the model on a different machine
+
+Only SAM 3 needs a GPU. The pipeline splits at that boundary, so the model can
+run on the CUDA box while everything else runs wherever you like:
+
+```bash
+# on the GPU machine
+python src/stairs_pipeline.py /path/to/bags \
+    --topic /camera/color/image_raw --prompt stairs \
+    --out output/stairs --stage segment
+
+# copy output/stairs_{stairs.json,masks.npz,frames.mp4} across, then anywhere:
+python src/stairs_pipeline.py --stage analyse --out output/stairs
+```
+
+Those three files are a complete handoff — the analyse stage never touches the
+bags, the model or CUDA. The masks are run-length encoded, so the bulk is just
+the frames video.
+
+This is worth using on a single machine too: retuning orientation costs seconds
+in the analyse stage instead of a full pass of the model.
+
 **Outputs** (`--out` stem):
 
 | File | Contents |
@@ -276,6 +298,18 @@ python src/stairs_pipeline.py ./photos/ --prompt stairs
 | `*_overlay.mp4` | frames with masks tinted and outlined, angle drawn and annotated |
 | `*_stairs.json` | per-frame angles, coverage, provenance, mcap timestamps |
 | `*_masks.npz` | RLE mask sidecar |
+| `*_frames.mp4` | the decoded frames, so the analyse stage can re-run standalone |
+
+### Hardware
+
+SAM 3 needs **CUDA**. The upstream package will not run on Apple Silicon — it
+calls `.cuda()` unconditionally, gates on `device.type == "cuda"`, and needs
+Triton kernels plus the `torch_generic_nms` CUDA extension
+([sam3#164](https://github.com/facebookresearch/sam3/issues/164)). `sam3_preflight.py`
+detects this and says so rather than reporting a missing GPU.
+
+Everything else — bag reading, orientation, overlay, the GUI, the test suite —
+needs no GPU and runs anywhere.
 
 ### Reading mcap bags
 

--- a/src/make_rois.py
+++ b/src/make_rois.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# make_rois.py
+"""Write rois.json from the command line — the headless twin of pick.py.
+
+    python src/make_rois.py --video input/crazyflo.mp4 \\
+        --start-frame 520 --end-frame 1200 \\
+        --roi cf1=940,234,87,57 --roi cf2=1619,88,119,84 \\
+        --roi cf3=1267,281,76,48 --roi payload=1278,546,26,34
+
+Boxes are `x,y,w,h` in pixels, top-left origin, matching what pick.py writes.
+`--from-json` seeds from an existing file so single values can be amended
+without retyping every box.
+
+    python src/make_rois.py --from-json src/rois.json --roi payload=1280,540,30,36
+    python src/make_rois.py --show                      # print the current file
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+
+DEFAULT_VIDEO = "input/crazyflo.mp4"
+DEFAULT_OUT = "src/rois.json"
+
+
+def parse_roi(spec: str) -> tuple[str, list[int]]:
+    """`name=x,y,w,h` → (name, [x, y, w, h])."""
+    if "=" not in spec:
+        raise ValueError(f"--roi wants name=x,y,w,h, got {spec!r}")
+    name, _, nums = spec.partition("=")
+    name = name.strip()
+    if not name:
+        raise ValueError(f"--roi is missing a name: {spec!r}")
+    parts = [p.strip() for p in nums.split(",")]
+    if len(parts) != 4:
+        raise ValueError(
+            f"--roi {name}: expected 4 numbers x,y,w,h, got {len(parts)}")
+    try:
+        box = [int(round(float(p))) for p in parts]
+    except ValueError as e:
+        raise ValueError(f"--roi {name}: {e}") from e
+    if box[2] <= 0 or box[3] <= 0:
+        raise ValueError(f"--roi {name}: width and height must be positive")
+    return name, box
+
+
+def video_info(path: str) -> tuple[int, int, int]:
+    """(total_frames, width, height); zeros when the video cannot be opened."""
+    cap = cv2.VideoCapture(path)
+    if not cap.isOpened():
+        return 0, 0, 0
+    n = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    cap.release()
+    return n, w, h
+
+
+def validate(rois: dict, start: int, end: int | None,
+             total: int, width: int, height: int) -> list[str]:
+    """Problems worth refusing to write — a bad box wastes a whole tracking run."""
+    errs: list[str] = []
+    if end is not None and end < start:
+        errs.append(f"end_frame {end} is before start_frame {start}")
+    if total and start >= total:
+        errs.append(f"start_frame {start} is past the last frame ({total - 1})")
+    if total and end is not None and end > total - 1:
+        errs.append(f"end_frame {end} is past the last frame ({total - 1})")
+    for name, (x, y, w, h) in rois.items():
+        if x < 0 or y < 0:
+            errs.append(f"{name}: negative origin ({x},{y})")
+        if width and x + w > width:
+            errs.append(f"{name}: box runs past the right edge "
+                        f"({x}+{w} > {width})")
+        if height and y + h > height:
+            errs.append(f"{name}: box runs past the bottom edge "
+                        f"({y}+{h} > {height})")
+    return errs
+
+
+def build(rois: dict, start: int, end: int | None) -> dict:
+    return {"start_frame": int(start),
+            "end_frame": None if end is None else int(end),
+            "rois": {k: list(v) for k, v in rois.items()}}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--video", default=DEFAULT_VIDEO)
+    p.add_argument("--out", default=DEFAULT_OUT)
+    p.add_argument("--roi", action="append", default=[], metavar="NAME=X,Y,W,H",
+                   help="one object's seed box; repeat per object")
+    p.add_argument("--start-frame", type=int, default=None)
+    p.add_argument("--end-frame", type=int, default=None)
+    p.add_argument("--from-json", default=None,
+                   help="seed from an existing rois.json and amend it")
+    p.add_argument("--drop", action="append", default=[], metavar="NAME",
+                   help="remove an object (with --from-json)")
+    p.add_argument("--show", action="store_true",
+                   help="print the resulting file instead of writing it")
+    p.add_argument("--force", action="store_true",
+                   help="write even if boxes fall outside the frame")
+    return p.parse_args(argv)
+
+
+def main(args: argparse.Namespace | None = None) -> int:
+    args = args or parse_args()
+
+    rois: dict = {}
+    start, end = 0, None
+    src = args.from_json or (args.out if args.show and Path(args.out).exists() else None)
+    if src:
+        if not Path(src).exists():
+            print(f"No such file: {src}", file=sys.stderr)
+            return 2
+        seed = json.loads(Path(src).read_text())
+        rois = dict(seed.get("rois", seed if "rois" not in seed else {}))
+        start = seed.get("start_frame", 0)
+        end = seed.get("end_frame")
+
+    for spec in args.roi:
+        try:
+            name, box = parse_roi(spec)
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            return 2
+        rois[name] = box
+
+    for name in args.drop:
+        rois.pop(name, None)
+
+    if args.start_frame is not None:
+        start = args.start_frame
+    if args.end_frame is not None:
+        end = args.end_frame
+
+    if not rois:
+        print("No ROIs. Pass --roi NAME=X,Y,W,H (repeatable), or --from-json.",
+              file=sys.stderr)
+        return 2
+
+    total, width, height = video_info(args.video)
+    if total:
+        if end is None:
+            end = total - 1
+        errs = validate(rois, start, end, total, width, height)
+        if errs:
+            for e in errs:
+                print(f"{'warning' if args.force else 'error'}: {e}",
+                      file=sys.stderr)
+            if not args.force:
+                print("Nothing written. Re-check the boxes, or pass --force.",
+                      file=sys.stderr)
+                return 1
+    else:
+        print(f"warning: cannot open {args.video}; boxes not checked against it",
+              file=sys.stderr)
+
+    data = build(rois, start, end)
+    if args.show:
+        print(json.dumps(data, indent=2))
+        return 0
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(data, indent=2))
+    span = f"{start}→{end}" if end is not None else f"{start}→end"
+    print(f"Wrote {args.out}: {len(rois)} object(s) ({', '.join(rois)}), "
+          f"frames {span}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/media.py
+++ b/src/media.py
@@ -138,7 +138,7 @@ def resolve(
         if kind == "mcap":
             if not topic:
                 raise ValueError(
-                    "mcap input needs a topic — run `python src/mcap_extract.py "
+                    "mcap input needs a topic — run `python src/stairs_pipeline.py "
                     f"--list {src}` to see what is in the bag"
                 )
             from mcap_source import extract_to_video

--- a/src/render.py
+++ b/src/render.py
@@ -9,8 +9,8 @@ Outputs (MP4, next to the JSON file):
     <stem>_persistent.mp4
     <stem>_transient.mp4
 
-Any trail property can be overridden via the RENDER_* env vars or by editing
-the OVERRIDES dict at the top of this file.
+Any trail property can be overridden on the command line (see --help) or by
+editing the OVERRIDES dict at the top of this file.
 
 Mask modes (need a *_masks.npz sidecar, written by
 `track_sam3.py --save-masks`; ignored when there is none):
@@ -96,12 +96,16 @@ def load_masks(data_file: str, want: bool) -> MaskStore | None:
     return store
 
 
-def render(data_file: str = DEFAULT_DATA_FILE, mask_mode: str = "off") -> None:
+def render(data_file: str = DEFAULT_DATA_FILE, mask_mode: str = "off",
+           overrides: dict | None = None) -> None:
     with open(data_file) as f:
         d = json.load(f)
 
-    # Apply overrides
+    # File-level overrides first, then per-run ones from the command line.
     for k, v in OVERRIDES.items():
+        if v is not None:
+            d[k] = v
+    for k, v in (overrides or {}).items():
         if v is not None:
             d[k] = v
 
@@ -241,9 +245,47 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--mask-mode", choices=("off", "occlude", "glow"), default="off",
                    help="use the *_masks.npz sidecar to composite objects over "
                         "the trails (default: off)")
+    p.add_argument("--thickness", type=int, default=None, help="trail line width")
+    p.add_argument("--alpha", type=float, default=None,
+                   help="trail opacity, 0-1")
+    p.add_argument("--trail-window", type=int, default=None,
+                   help="frames kept in the transient trail")
+    p.add_argument("--smooth", dest="smooth", action="store_true", default=None,
+                   help="smooth trails (default: as recorded)")
+    p.add_argument("--no-smooth", dest="smooth", action="store_false",
+                   help="draw raw tracked points")
+    p.add_argument("--color", action="append", default=[], metavar="NAME=B,G,R",
+                   help="override one trail colour; repeat per object")
+    p.add_argument("--trail-start-sec", type=float, default=None)
+    p.add_argument("--trail-end-sec", type=float, default=None)
     return p.parse_args(argv)
+
+
+def overrides_from_args(args: argparse.Namespace, data_file: str) -> dict:
+    """CLI flags → the same keys the tracking JSON uses."""
+    out = {
+        "trail_thickness": args.thickness,
+        "alpha": args.alpha,
+        "trail_window": args.trail_window,
+        "smooth_trails": args.smooth,
+        "trail_start_sec": args.trail_start_sec,
+        "trail_end_sec": args.trail_end_sec,
+    }
+    if args.color:
+        with open(data_file) as f:
+            colors = dict(json.load(f).get("trail_color", {}))
+        for spec in args.color:
+            if "=" not in spec:
+                raise SystemExit(f"--color wants NAME=B,G,R, got {spec!r}")
+            name, _, nums = spec.partition("=")
+            parts = [p.strip() for p in nums.split(",")]
+            if len(parts) != 3:
+                raise SystemExit(f"--color {name}: expected 3 numbers B,G,R")
+            colors[name.strip()] = [int(p) for p in parts]
+        out["trail_color"] = colors
+    return out
 
 
 if __name__ == "__main__":
     _a = parse_args()
-    render(_a.data_file, _a.mask_mode)
+    render(_a.data_file, _a.mask_mode, overrides_from_args(_a, _a.data_file))

--- a/src/sam3_preflight.py
+++ b/src/sam3_preflight.py
@@ -33,6 +33,14 @@ MIN_CUDA   = (12, 6)
 
 OK, WARN, FAIL = "  ok  ", " warn ", " FAIL "
 
+APPLE_SILICON_NOTE = (
+    "facebookresearch/sam3 is CUDA-only and will not run here — it calls "
+    ".cuda() unconditionally, gates on device.type == 'cuda', and needs Triton "
+    "kernels and the torch_generic_nms CUDA extension "
+    "(github.com/facebookresearch/sam3/issues/164). Use a CUDA machine, or the "
+    "Hugging Face transformers implementation, which is reported to run on MPS"
+)
+
 
 def _line(status: str, label: str, detail: str = "") -> None:
     print(f"[{status}] {label}" + (f" — {detail}" if detail else ""))
@@ -46,6 +54,19 @@ def check_python() -> bool:
         return True
     _line(FAIL, "python", f"{got}, SAM 3 needs ≥ {MIN_PYTHON[0]}.{MIN_PYTHON[1]}")
     return False
+
+
+def detect_backend() -> str:
+    """Which accelerator this machine has: cuda | mps | cpu | none."""
+    try:
+        import torch
+    except ImportError:
+        return "none"
+    if torch.cuda.is_available():
+        return "cuda"
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
 
 
 def check_torch() -> bool:
@@ -63,33 +84,50 @@ def check_torch() -> bool:
         _line(FAIL, "torch", f"{ver}, SAM 3 needs ≥ {MIN_TORCH[0]}.{MIN_TORCH[1]}")
         return False
 
-    if not torch.cuda.is_available():
-        _line(FAIL, "cuda", "torch.cuda.is_available() is False — SAM 3 video "
-                            "tracking needs a GPU")
+    backend = detect_backend()
+
+    if backend == "cuda":
+        cuda_ver = torch.version.cuda or "unknown"
+        try:
+            cparts = tuple(int(x) for x in cuda_ver.split(".")[:2])
+            status = OK if cparts >= MIN_CUDA else WARN
+        except ValueError:
+            status = WARN
+        _line(status, "cuda", f"torch built against {cuda_ver} "
+                              f"(recommended ≥ {MIN_CUDA[0]}.{MIN_CUDA[1]})")
+        for i in range(torch.cuda.device_count()):
+            p = torch.cuda.get_device_properties(i)
+            gb = p.total_memory / 1024 ** 3
+            _line(OK if gb >= 16 else WARN, f"gpu{i}", f"{p.name}, {gb:.1f} GB")
+        return True
+
+    if backend == "mps":
+        # Apple Silicon.  CUDA is not merely absent, it is impossible — so
+        # report the real blocker rather than "install a GPU".
+        _line(WARN, "accelerator", "Apple Silicon GPU (MPS) — no CUDA, and none "
+                                   "is possible on this hardware")
+        _line(FAIL, "backend", APPLE_SILICON_NOTE)
         return False
 
-    cuda_ver = torch.version.cuda or "unknown"
-    try:
-        cparts = tuple(int(x) for x in cuda_ver.split(".")[:2])
-        status = OK if cparts >= MIN_CUDA else WARN
-    except ValueError:
-        status = WARN
-    _line(status, "cuda", f"torch built against {cuda_ver} "
-                          f"(recommended ≥ {MIN_CUDA[0]}.{MIN_CUDA[1]})")
-
-    for i in range(torch.cuda.device_count()):
-        p = torch.cuda.get_device_properties(i)
-        gb = p.total_memory / 1024 ** 3
-        status = OK if gb >= 16 else WARN
-        _line(status, f"gpu{i}", f"{p.name}, {gb:.1f} GB")
-    return True
+    _line(FAIL, "accelerator",
+          "no CUDA and no MPS — SAM 3 needs a GPU; CPU-only inference on an "
+          "848M-parameter video model is impractical")
+    return False
 
 
 def check_sam3() -> bool:
+    if detect_backend() == "mps":
+        # Installing it here would only produce a confusing runtime failure.
+        _line(WARN, "sam3", "skipped — the official package cannot run on this "
+                            "hardware (see above)")
+        return False
+
     try:
         mod = importlib.import_module("sam3.model_builder")
     except ImportError as e:
-        _line(FAIL, "sam3", f"{e} — clone facebookresearch/sam3 and `pip install -e .`")
+        _line(FAIL, "sam3",
+              f"{e} — git clone https://github.com/facebookresearch/sam3 "
+              "&& pip install -e sam3")
         return False
     if not hasattr(mod, "build_sam3_video_predictor"):
         _line(FAIL, "sam3", "sam3.model_builder has no build_sam3_video_predictor — "
@@ -151,10 +189,18 @@ def main() -> int:
         print("All checks passed — `python src/track_sam3.py` should run.")
         return 0
     print("Preflight failed. Fix the FAIL lines above, then re-run.")
-    print("If you have no local weights file, SAM 3 downloads a gated checkpoint:")
-    print("  request access at https://huggingface.co/facebook/sam3, then")
-    print("  `huggingface-cli login`.  A local file avoids this entirely — point")
-    print(f"  ${CHECKPOINT_ENV} or --checkpoint at it.")
+    if detect_backend() == "mps":
+        print()
+        print("On Apple Silicon the model cannot run, but everything around it")
+        print("can — these need no GPU and are worth checking now:")
+        print("  python tests/make_bag.py /tmp/fakebag --angle 25")
+        print("  python src/stairs_pipeline.py --list /tmp/fakebag")
+        print("  python -m unittest discover -s tests")
+    else:
+        print("If you have no local weights file, SAM 3 downloads a gated checkpoint:")
+        print("  request access at https://huggingface.co/facebook/sam3, then")
+        print("  `huggingface-cli login`.  A local file avoids this entirely — point")
+        print(f"  ${CHECKPOINT_ENV} or --checkpoint at it.")
     return 1
 
 

--- a/src/stairs_pipeline.py
+++ b/src/stairs_pipeline.py
@@ -33,7 +33,7 @@ import numpy as np
 
 import stair_orientation as so
 from maskstore import MaskStore
-from media import Media, resolve
+from media import resolve
 from sam3_backend import (
     FrameWindow,
     Sam3Config,
@@ -66,9 +66,10 @@ def _color(i: int) -> tuple[int, int, int]:
     return MASK_COLORS[i % len(MASK_COLORS)]
 
 
-def render_overlay(
-    media: Media,
-    window: FrameWindow,
+def _render_overlay_frames(
+    frames: list,
+    start_frame: int,
+    fps: float,
     masks: MaskStore,
     id_to_name: dict[int, str],
     orientations: list[so.Orientation] | None,
@@ -76,12 +77,19 @@ def render_overlay(
     *,
     draw_orientation: bool = True,
 ) -> str | None:
-    """Tint each object's mask over the frame, and annotate the angle."""
+    """Tint each object's mask over the frame, and annotate the angle.
+
+    Takes decoded frames rather than a live FrameWindow, so this runs from the
+    stage-1 artifacts alone — no bag, no GPU, no re-extraction.
+    """
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    if not frames:
+        logging.error("No frames to render")
+        return None
+    h, w = frames[0].shape[:2]
     writer = cv2.VideoWriter(
-        str(out_path), cv2.VideoWriter.fourcc(*"mp4v"), media.fps,
-        (window.width, window.height))
+        str(out_path), cv2.VideoWriter.fourcc(*"mp4v"), fps, (w, h))
     if not writer.isOpened():
         logging.error(f"Cannot open overlay video for writing: {out_path}")
         return None
@@ -89,11 +97,9 @@ def render_overlay(
     by_frame = {o.frame: o for o in (orientations or [])}
     names = list(id_to_name.values())
 
-    for local in range(window.n_frames):
-        abs_idx = window.to_absolute(local)
-        frame = window.read_frame(abs_idx)
-        if frame is None:
-            continue
+    for local, frame in enumerate(frames):
+        abs_idx = start_frame + local
+        frame = frame.copy()
 
         for i, name in enumerate(names):
             m = masks.get(abs_idx, name)
@@ -124,7 +130,7 @@ def render_overlay(
     return str(out_path)
 
 
-def run(
+def segment(
     source: str | Path,
     *,
     prompt: str = "stairs",
@@ -136,20 +142,22 @@ def run(
     checkpoint: str | None = None,
     min_score: float = 0.0,
     reprompt_every: int = 0,
-    orientation: bool = True,
-    overlay: bool = True,
-    orientation_cfg: so.OrientationConfig | None = None,
+    keep_video: bool = True,
     predictor=None,
     progress=None,
     log=print,
-) -> StairsResult:
-    """Full run.  `progress`/`log` are hooks so a GUI can follow along."""
+) -> dict:
+    """Stage 1 — run SAM 3 and persist masks.  THIS IS THE STAGE THAT NEEDS A GPU.
+
+    Writes `<stem>_masks.npz`, `<stem>_frames.mp4` and `<stem>_stairs.json`.
+    Those three files are a complete handoff: `analyse()` needs nothing else, so
+    the model can run on the GPU machine and everything downstream elsewhere.
+    """
     out_stem = Path(out_stem)
     out_stem.parent.mkdir(parents=True, exist_ok=True)
 
     log(f"Resolving input: {source}")
-    media = resolve(source, topic=topic, max_frames=max_frames,
-                    progress=progress)
+    media = resolve(source, topic=topic, max_frames=max_frames, progress=progress)
     window: FrameWindow | None = None
     try:
         log(f"  {media.kind}: {media.frames} frames "
@@ -201,41 +209,23 @@ def run(
             (log if cov >= 0.9 else
              (lambda m: log("WARNING: " + m)))(f"  {name}: seen in {100*cov:.0f}% of frames")
 
-        # ── Orientation ───────────────────────────────────────────────────────
-        ori: list[so.Orientation] = []
-        ori_summary: dict = {}
-        if orientation and id_to_name:
-            cfgo = orientation_cfg or so.OrientationConfig()
-            primary = _largest_object(results, id_to_name)
-            log(f"Measuring orientation of {primary!r} …")
-            for local in range(window.n_frames):
-                abs_idx = window.to_absolute(local)
-                frame = window.read_frame(abs_idx)
-                if frame is None:
-                    continue
-                ori.append(so.estimate_frame(
-                    frame, masks.get(abs_idx, primary), abs_idx, cfgo))
-            ori = so.smooth_series(ori, cfgo.smooth_window)
-            ori_summary = so.summarise(ori)
-            ori_summary["object"] = primary
-            if ori_summary.get("angle_deg_mean") is None:
-                log("  no dominant edge direction found in any frame")
-            else:
-                log(f"  mean angle {ori_summary['angle_deg_mean']:.1f}deg "
-                    f"(sd {ori_summary['angle_deg_std']:.1f}, "
-                    f"{100*ori_summary['coverage']:.0f}% of frames)")
-
-        # ── Outputs ───────────────────────────────────────────────────────────
-        overlay_path = None
-        if overlay and id_to_name:
-            overlay_path = render_overlay(
-                media, window, masks, id_to_name, ori,
-                out_stem.with_name(out_stem.name + "_overlay.mp4"))
-            if overlay_path:
-                log(f"Overlay → {overlay_path}")
+        # Area per object, so analyse() can pick the primary one without the
+        # per-frame observations, which are not part of the handoff.
+        areas: dict[str, float] = {}
+        for per_obj in results.values():
+            for oid, obs in per_obj.items():
+                n = id_to_name.get(oid)
+                if n:
+                    areas[n] = areas.get(n, 0.0) + obs.area
 
         mask_path = out_stem.with_name(out_stem.name + "_masks.npz")
         masks.save(mask_path)
+
+        frames_path = None
+        if keep_video:
+            frames_path = out_stem.with_name(out_stem.name + "_frames.mp4")
+            _persist_window(window, media.fps, frames_path)
+            log(f"Frames → {frames_path}")
 
         data = {
             "source": str(source),
@@ -251,8 +241,10 @@ def run(
             "frames": window.n_frames,
             "objects": {str(o): n for o, n in id_to_name.items()},
             "coverage": coverage,
-            "orientation": ori_summary,
+            "areas": areas,
+            "orientation": {},
             "masks": str(mask_path),
+            "frames_video": str(frames_path) if frames_path else None,
         }
         if media.kind == "mcap":
             data["timestamps_ns"] = media.detail.get("timestamps_ns", [])
@@ -261,32 +253,178 @@ def run(
         data_path.write_text(json.dumps(data, indent=2))
         log(f"Data → {data_path}")
         log(f"Masks → {mask_path}")
-
-        return StairsResult(
-            video=str(media.video), overlay=overlay_path, data=str(data_path),
-            frames=window.n_frames, objects=id_to_name, coverage=coverage,
-            orientation=ori_summary,
-        )
+        return data
     finally:
         if window is not None:
             window.cleanup()
         media.cleanup()
 
 
+def _persist_window(window: FrameWindow, fps: float, out: Path) -> None:
+    """Copy the extracted frames into an mp4 that outlives the temp dir."""
+    writer = cv2.VideoWriter(str(out), cv2.VideoWriter.fourcc(*"mp4v"), fps,
+                             (window.width, window.height))
+    if not writer.isOpened():
+        raise RuntimeError(f"Cannot open {out} for writing")
+    for local in range(window.n_frames):
+        frame = window.read_frame(window.to_absolute(local))
+        if frame is not None:
+            writer.write(frame)
+    writer.release()
+
+
+def analyse(
+    out_stem: str | Path = "output/stairs",
+    *,
+    orientation: bool = True,
+    overlay: bool = True,
+    orientation_cfg: so.OrientationConfig | None = None,
+    frames_video: str | Path | None = None,
+    log=print,
+) -> StairsResult:
+    """Stage 2 — orientation and overlay from stage 1's output.  NO GPU NEEDED.
+
+    Re-runnable: retuning orientation costs seconds here rather than a full
+    pass of the model.
+    """
+    out_stem = Path(out_stem)
+    data_path = out_stem.with_name(out_stem.name + "_stairs.json")
+    if not data_path.exists():
+        raise FileNotFoundError(
+            f"{data_path} not found — run the segment stage first "
+            f"(python src/stairs_pipeline.py <source> --stage segment)"
+        )
+    data = json.loads(data_path.read_text())
+
+    mask_path = Path(data.get("masks") or
+                     out_stem.with_name(out_stem.name + "_masks.npz"))
+    if not mask_path.exists():
+        raise FileNotFoundError(f"Mask sidecar missing: {mask_path}")
+    masks = MaskStore.load(mask_path)
+
+    # Guard the unset case separately: Path("") is Path("."), which exists, so
+    # a bare exists() check would sail past a missing record and fail later
+    # with an unhelpful "cannot open ." from VideoCapture.
+    recorded = frames_video or data.get("frames_video")
+    if not recorded:
+        raise FileNotFoundError(
+            "No frames video recorded by the segment stage — re-run it with "
+            "--keep-video (the default), or point --frames-video at the clip."
+        )
+    video = Path(recorded)
+    if not video.exists():
+        raise FileNotFoundError(
+            f"Frames video missing: {video}. Copy it across from the machine "
+            f"that ran the segment stage, or pass --frames-video."
+        )
+
+    id_to_name = {int(k): v for k, v in data["objects"].items()}
+    start = int(data["start_frame"])
+    n_frames = int(data["frames"])
+    fps = float(data["fps"])
+
+    cap = cv2.VideoCapture(str(video))
+    if not cap.isOpened():
+        raise RuntimeError(f"Cannot open {video}")
+    frames: list = []
+    while True:
+        ok, f = cap.read()
+        if not ok:
+            break
+        frames.append(f)
+    cap.release()
+    if len(frames) < n_frames:
+        log(f"WARNING: {video.name} has {len(frames)} frames, expected {n_frames}")
+        n_frames = len(frames)
+
+    ori: list[so.Orientation] = []
+    ori_summary: dict = {}
+    if orientation and id_to_name:
+        cfgo = orientation_cfg or so.OrientationConfig()
+        primary = _primary_from_areas(data.get("areas") or {}, id_to_name)
+        log(f"Measuring orientation of {primary!r} …")
+        for local in range(n_frames):
+            abs_idx = start + local
+            ori.append(so.estimate_frame(
+                frames[local], masks.get(abs_idx, primary), abs_idx, cfgo))
+        ori = so.smooth_series(ori, cfgo.smooth_window)
+        ori_summary = so.summarise(ori)
+        ori_summary["object"] = primary
+        if ori_summary.get("angle_deg_mean") is None:
+            log("  no dominant edge direction found in any frame")
+        else:
+            log(f"  mean angle {ori_summary['angle_deg_mean']:.1f}deg "
+                f"(sd {ori_summary['angle_deg_std']:.1f}, "
+                f"{100*ori_summary['coverage']:.0f}% of frames)")
+
+    overlay_path = None
+    if overlay and id_to_name:
+        overlay_path = _render_overlay_frames(
+            frames[:n_frames], start, fps, masks, id_to_name, ori,
+            out_stem.with_name(out_stem.name + "_overlay.mp4"))
+        if overlay_path:
+            log(f"Overlay → {overlay_path}")
+
+    data["orientation"] = ori_summary
+    data_path.write_text(json.dumps(data, indent=2))
+
+    return StairsResult(
+        video=str(video), overlay=overlay_path, data=str(data_path),
+        frames=n_frames, objects=id_to_name,
+        coverage=data.get("coverage", {}), orientation=ori_summary,
+    )
+
+
+def run(
+    source: str | Path,
+    *,
+    prompt: str = "stairs",
+    topic: str | None = None,
+    out_stem: str | Path = "output/stairs",
+    max_frames: int | None = None,
+    start_frame: int = 0,
+    end_frame: int | None = None,
+    checkpoint: str | None = None,
+    min_score: float = 0.0,
+    reprompt_every: int = 0,
+    orientation: bool = True,
+    overlay: bool = True,
+    orientation_cfg: so.OrientationConfig | None = None,
+    keep_video: bool = True,
+    predictor=None,
+    progress=None,
+    log=print,
+) -> StairsResult:
+    """Both stages back to back, for when one machine does everything."""
+    data = segment(
+        source, prompt=prompt, topic=topic, out_stem=out_stem,
+        max_frames=max_frames, start_frame=start_frame, end_frame=end_frame,
+        checkpoint=checkpoint, min_score=min_score,
+        reprompt_every=reprompt_every, keep_video=keep_video,
+        predictor=predictor, progress=progress, log=log,
+    )
+    if not data["objects"]:
+        # Nothing was found; there is nothing for stage 2 to measure or draw.
+        return StairsResult(
+            video=data.get("frames_video") or "", overlay=None,
+            data=str(Path(out_stem).with_name(Path(out_stem).name + "_stairs.json")),
+            frames=int(data["frames"]), objects={},
+            coverage=data.get("coverage", {}), orientation={},
+        )
+    return analyse(out_stem, orientation=orientation, overlay=overlay,
+                   orientation_cfg=orientation_cfg, log=log)
+
+
+def _primary_from_areas(areas: dict, id_to_name: dict[int, str]) -> str:
+    """Biggest object by accumulated mask area — the staircase, not a stray step."""
+    if areas:
+        return max(areas, key=areas.get)
+    return next(iter(id_to_name.values()))
+
+
 def _slug(text: str) -> str:
     keep = "".join(c if c.isalnum() else "_" for c in text.strip().lower())
     return keep.strip("_") or "obj"
-
-
-def _largest_object(results, id_to_name: dict[int, str]) -> str:
-    """The object with the most mask area — the staircase, not a stray step."""
-    totals: dict[int, float] = {}
-    for per_obj in results.values():
-        for oid, obs in per_obj.items():
-            totals[oid] = totals.get(oid, 0.0) + obs.area
-    if not totals:
-        return next(iter(id_to_name.values()))
-    return id_to_name[max(totals, key=totals.get)]
 
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
@@ -309,6 +447,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--reprompt-every", type=int, default=0)
     p.add_argument("--no-orientation", action="store_true")
     p.add_argument("--no-overlay", action="store_true")
+    p.add_argument("--stage", choices=("all", "segment", "analyse"), default="all",
+                   help="'segment' runs SAM 3 and needs a CUDA GPU; 'analyse' "
+                        "does orientation and overlay from its output and needs "
+                        "none, so the two can run on different machines "
+                        "(default: all)")
+    p.add_argument("--frames-video", default=None,
+                   help="override the frames mp4 the analyse stage reads")
+    p.add_argument("--no-keep-video", action="store_true",
+                   help="do not persist the frames mp4 (analyse then cannot run "
+                        "separately)")
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -318,6 +466,12 @@ def main(args: argparse.Namespace | None = None) -> int:
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(levelname)s: %(message)s")
+
+    # The analyse stage reads stage 1's artifacts, so it takes no source at all.
+    if args.stage == "analyse":
+        analyse(args.out, orientation=not args.no_orientation,
+                overlay=not args.no_overlay, frames_video=args.frames_video)
+        return 0
 
     if not args.source:
         print("Give a source. Try --help.")
@@ -334,11 +488,28 @@ def main(args: argparse.Namespace | None = None) -> int:
             print("  " + t.describe())
         return 0
 
+    if args.stage == "segment":
+        segment(args.source, prompt=args.prompt, topic=args.topic,
+                out_stem=args.out, max_frames=args.max_frames,
+                start_frame=args.start_frame, end_frame=args.end_frame,
+                checkpoint=args.checkpoint, min_score=args.min_score,
+                reprompt_every=args.reprompt_every,
+                keep_video=not args.no_keep_video)
+        print("\nSegment stage done. Copy these to wherever you want to analyse:")
+        stem = Path(args.out)
+        for suffix in ("_stairs.json", "_masks.npz", "_frames.mp4"):
+            p = stem.with_name(stem.name + suffix)
+            if p.exists():
+                print(f"  {p}  ({p.stat().st_size / 1e6:.1f} MB)")
+        print(f"\nThen: python src/stairs_pipeline.py --stage analyse --out {args.out}")
+        return 0
+
     run(args.source, prompt=args.prompt, topic=args.topic, out_stem=args.out,
         max_frames=args.max_frames, start_frame=args.start_frame,
         end_frame=args.end_frame, checkpoint=args.checkpoint,
         min_score=args.min_score, reprompt_every=args.reprompt_every,
-        orientation=not args.no_orientation, overlay=not args.no_overlay)
+        orientation=not args.no_orientation, overlay=not args.no_overlay,
+        keep_video=not args.no_keep_video)
     return 0
 
 

--- a/src/to_webm.py
+++ b/src/to_webm.py
@@ -1,49 +1,77 @@
-"""to_webm.py — convert all MP4 files in output/ to WebM (VP9) in output/webm/.
+"""to_webm.py — convert MP4 files to WebM (VP9).
 
 Usage:
-    python src/to_webm.py              # scans output/
-    python src/to_webm.py path/to/dir  # scans a custom directory
+    python src/to_webm.py                        # scans output/
+    python src/to_webm.py path/to/dir            # a custom directory
+    python src/to_webm.py a.mp4 b.mp4            # named files
+    python src/to_webm.py --bitrate 4M --out-dir web/
 """
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
 
 INPUT_DIR  = Path("output")
-OUTPUT_DIR = INPUT_DIR / "webm"
 BITRATE    = "2M"
 
 
-def convert(src: Path, dst: Path) -> None:
+def convert(src: Path, dst: Path, bitrate: str = BITRATE,
+            timeout: int = 600) -> None:
     dst.parent.mkdir(parents=True, exist_ok=True)
     r = subprocess.run(
         ["ffmpeg", "-y", "-i", str(src),
-         "-c:v", "libvpx-vp9", "-b:v", BITRATE, str(dst)],
-        capture_output=True, timeout=600,
+         "-c:v", "libvpx-vp9", "-b:v", bitrate, str(dst)],
+        capture_output=True, timeout=timeout,
     )
     if r.returncode != 0:
         raise RuntimeError(f"ffmpeg failed for {src.name}: {r.stderr[:300].decode(errors='replace')}")
 
 
-def main(scan_dir: Path = INPUT_DIR) -> None:
-    mp4s = sorted(scan_dir.glob("*.mp4"))
-    if not mp4s:
-        print(f"No MP4 files found in {scan_dir}")
-        return
+def collect(paths: list[str]) -> tuple[list[Path], Path]:
+    """Resolve arguments into (files, default output dir)."""
+    if not paths:
+        return sorted(INPUT_DIR.glob("*.mp4")), INPUT_DIR / "webm"
+    if len(paths) == 1 and Path(paths[0]).is_dir():
+        d = Path(paths[0])
+        return sorted(d.glob("*.mp4")), d / "webm"
+    files = [Path(p) for p in paths]
+    missing = [f for f in files if not f.is_file()]
+    if missing:
+        raise FileNotFoundError(f"No such file(s): {', '.join(map(str, missing))}")
+    return files, files[0].parent / "webm"
 
-    out_dir = scan_dir / "webm"
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("paths", nargs="*",
+                   help="MP4 files, or a directory to scan (default: output/)")
+    p.add_argument("--bitrate", default=BITRATE)
+    p.add_argument("--out-dir", default=None)
+    return p.parse_args(argv)
+
+
+def main(args: argparse.Namespace | None = None) -> int:
+    args = args or parse_args()
+    mp4s, default_out = collect(args.paths)
+    if not mp4s:
+        print("No MP4 files found")
+        return 1
+
+    out_dir = Path(args.out_dir) if args.out_dir else default_out
     out_dir.mkdir(parents=True, exist_ok=True)
 
     for src in mp4s:
         dst = out_dir / src.with_suffix(".webm").name
-        print(f"  {src.name} → webm/{dst.name} …", end=" ", flush=True)
-        convert(src, dst)
+        print(f"  {src.name} → {dst.name} …", end=" ", flush=True)
+        convert(src, dst, args.bitrate)
         print("done")
 
     print(f"\nConverted {len(mp4s)} file(s) → {out_dir}")
+    return 0
 
 
 if __name__ == "__main__":
-    scan = Path(sys.argv[1]) if len(sys.argv) > 1 else INPUT_DIR
-    main(scan)
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# tests/test_cli.py
+"""Every capability must be reachable from the command line."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cv2                                                  # noqa: E402
+
+import make_rois                                            # noqa: E402
+import render                                               # noqa: E402
+import to_webm                                              # noqa: E402
+
+
+def write_video(path: Path, n: int = 30, w: int = 64, h: int = 48) -> None:
+    wr = cv2.VideoWriter(str(path), cv2.VideoWriter.fourcc(*"mp4v"), 30.0, (w, h))
+    for i in range(n):
+        wr.write(np.full((h, w, 3), i % 255, dtype=np.uint8))
+    wr.release()
+
+
+class TestMakeRois(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.video = self.dir / "v.mp4"
+        write_video(self.video, n=30, w=64, h=48)
+        self.out = self.dir / "rois.json"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, argv):
+        return make_rois.main(make_rois.parse_args(argv))
+
+    def _base(self, *extra):
+        return ["--video", str(self.video), "--out", str(self.out), *extra]
+
+    def test_parse_roi(self):
+        self.assertEqual(make_rois.parse_roi("cf1=10,20,30,40"),
+                         ("cf1", [10, 20, 30, 40]))
+
+    def test_parse_roi_rejects_bad_input(self):
+        for bad in ("cf1", "cf1=1,2,3", "=1,2,3,4", "cf1=a,b,c,d",
+                    "cf1=1,2,0,4"):
+            with self.assertRaises(ValueError, msg=bad):
+                make_rois.parse_roi(bad)
+
+    def test_writes_a_file_track_py_can_read(self):
+        code = self._run(self._base("--roi", "cf1=10,10,20,20",
+                                    "--start-frame", "5", "--end-frame", "25"))
+        self.assertEqual(code, 0)
+        d = json.loads(self.out.read_text())
+        self.assertEqual(d["start_frame"], 5)
+        self.assertEqual(d["end_frame"], 25)
+        self.assertEqual(d["rois"]["cf1"], [10, 10, 20, 20])
+
+    def test_multiple_rois(self):
+        self._run(self._base("--roi", "a=1,1,10,10", "--roi", "b=20,20,10,10"))
+        self.assertEqual(sorted(json.loads(self.out.read_text())["rois"]),
+                         ["a", "b"])
+
+    def test_end_frame_defaults_to_last_frame(self):
+        self._run(self._base("--roi", "a=1,1,10,10"))
+        self.assertEqual(json.loads(self.out.read_text())["end_frame"], 29)
+
+    def test_box_outside_the_frame_is_refused(self):
+        code = self._run(self._base("--roi", "a=60,40,50,50"))
+        self.assertEqual(code, 1)
+        self.assertFalse(self.out.exists())
+
+    def test_force_writes_anyway(self):
+        self.assertEqual(
+            self._run(self._base("--roi", "a=60,40,50,50", "--force")), 0)
+        self.assertTrue(self.out.exists())
+
+    def test_end_before_start_is_refused(self):
+        self.assertEqual(
+            self._run(self._base("--roi", "a=1,1,10,10",
+                                 "--start-frame", "20", "--end-frame", "5")), 1)
+
+    def test_amending_an_existing_file(self):
+        self._run(self._base("--roi", "a=1,1,10,10", "--roi", "b=2,2,10,10"))
+        self._run(self._base("--from-json", str(self.out),
+                             "--roi", "b=5,5,12,12"))
+        d = json.loads(self.out.read_text())
+        self.assertEqual(d["rois"]["a"], [1, 1, 10, 10])     # untouched
+        self.assertEqual(d["rois"]["b"], [5, 5, 12, 12])     # amended
+
+    def test_dropping_an_object(self):
+        self._run(self._base("--roi", "a=1,1,10,10", "--roi", "b=2,2,10,10"))
+        self._run(self._base("--from-json", str(self.out), "--drop", "a"))
+        self.assertEqual(list(json.loads(self.out.read_text())["rois"]), ["b"])
+
+    def test_no_rois_is_an_error(self):
+        self.assertEqual(self._run(self._base()), 2)
+
+    def test_bad_roi_syntax_exits_nonzero(self):
+        self.assertEqual(self._run(self._base("--roi", "nonsense")), 2)
+
+    def test_show_prints_without_writing(self):
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self._run(self._base("--roi", "a=1,1,10,10", "--show"))
+        self.assertIn('"start_frame"', buf.getvalue())
+        self.assertFalse(self.out.exists())
+
+    def test_missing_video_still_writes_with_a_warning(self):
+        code = self._run(["--video", str(self.dir / "nope.mp4"),
+                          "--out", str(self.out), "--roi", "a=1,1,10,10"])
+        self.assertEqual(code, 0)
+        self.assertTrue(self.out.exists())
+
+
+class TestRenderOverrides(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.json = self.dir / "x_tracking.json"
+        self.json.write_text(json.dumps({
+            "video_in": "v.mp4", "fps": 30.0, "total_frames": 10,
+            "width": 64, "height": 48, "start_frame": 0, "end_frame": 9,
+            "trail_start_sec": 0, "trail_end_sec": 0,
+            "trail_color": {"cf1": [0, 0, 255]}, "trail_thickness": 3,
+            "alpha": 0.6, "trail_window": 200, "smooth_trails": True,
+            "trails": {"cf1": {"0": [1, 2]}},
+        }))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _ov(self, argv):
+        a = render.parse_args([str(self.json), *argv])
+        return render.overrides_from_args(a, str(self.json))
+
+    def test_numeric_overrides(self):
+        o = self._ov(["--thickness", "7", "--alpha", "0.25",
+                      "--trail-window", "50"])
+        self.assertEqual(o["trail_thickness"], 7)
+        self.assertEqual(o["alpha"], 0.25)
+        self.assertEqual(o["trail_window"], 50)
+
+    def test_unset_flags_stay_none_so_the_json_wins(self):
+        o = self._ov([])
+        self.assertTrue(all(v is None for v in o.values()))
+
+    def test_smooth_toggles_both_ways(self):
+        self.assertTrue(self._ov(["--smooth"])["smooth_trails"])
+        self.assertFalse(self._ov(["--no-smooth"])["smooth_trails"])
+
+    def test_colour_override_keeps_the_others(self):
+        self.json.write_text(json.dumps({
+            **json.loads(self.json.read_text()),
+            "trail_color": {"cf1": [0, 0, 255], "cf2": [0, 255, 0]}}))
+        o = self._ov(["--color", "cf1=255,0,0"])
+        self.assertEqual(o["trail_color"]["cf1"], [255, 0, 0])
+        self.assertEqual(o["trail_color"]["cf2"], [0, 255, 0])
+
+    def test_bad_colour_exits(self):
+        with self.assertRaises(SystemExit):
+            self._ov(["--color", "cf1=1,2"])
+        with self.assertRaises(SystemExit):
+            self._ov(["--color", "nonsense"])
+
+    def test_overrides_reach_the_renderer(self):
+        write_video(self.dir / "v.mp4", n=10, w=64, h=48)
+        d = json.loads(self.json.read_text())
+        d["video_in"] = str(self.dir / "v.mp4")
+        self.json.write_text(json.dumps(d))
+        render.render(str(self.json), "off", {"trail_thickness": 9})
+        self.assertTrue((self.dir / "x_persistent.mp4").exists())
+
+
+class TestToWebm(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_collect_from_directory(self):
+        (self.dir / "a.mp4").write_bytes(b"x")
+        (self.dir / "b.mp4").write_bytes(b"x")
+        files, out = to_webm.collect([str(self.dir)])
+        self.assertEqual([f.name for f in files], ["a.mp4", "b.mp4"])
+        self.assertEqual(out, self.dir / "webm")
+
+    def test_collect_named_files(self):
+        p = self.dir / "a.mp4"
+        p.write_bytes(b"x")
+        files, out = to_webm.collect([str(p)])
+        self.assertEqual(files, [p])
+        self.assertEqual(out, self.dir / "webm")
+
+    def test_collect_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            to_webm.collect([str(self.dir / "nope.mp4")])
+
+    def test_args(self):
+        a = to_webm.parse_args(["x.mp4", "--bitrate", "4M", "--out-dir", "w"])
+        self.assertEqual((a.bitrate, a.out_dir), ("4M", "w"))
+
+
+class TestEveryToolHasACli(unittest.TestCase):
+    """Anything a user runs directly must expose --help."""
+
+    ENTRY_POINTS = [
+        "make_rois.py", "track.py", "track_sam3.py", "render.py",
+        "to_webm.py", "stairs_pipeline.py", "sam3_preflight.py",
+    ]
+
+    def test_help_works(self):
+        import subprocess
+        for name in self.ENTRY_POINTS:
+            path = ROOT / "src" / name
+            self.assertTrue(path.exists(), name)
+            r = subprocess.run([sys.executable, str(path), "--help"],
+                               capture_output=True, timeout=60, cwd=ROOT)
+            # sam3_preflight takes no arguments; it just must not crash.
+            self.assertIn(r.returncode, (0, 1, 2), f"{name}: {r.stderr[:200]}")
+
+    def test_no_dangling_module_references(self):
+        # A help string that names a file which does not exist sends the user
+        # down a dead end.
+        import re
+        for src in (ROOT / "src").glob("*.py"):
+            text = src.read_text()
+            for ref in re.findall(r"src/([a-z_]+\.py)", text):
+                self.assertTrue((ROOT / "src" / ref).exists(),
+                                f"{src.name} references missing src/{ref}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stairs_pipeline.py
+++ b/tests/test_stairs_pipeline.py
@@ -246,6 +246,129 @@ def _no_detections(fp):
     return handler
 
 
+class TestStageSplit(unittest.TestCase):
+    """The GPU boundary: segment needs CUDA, analyse does not."""
+
+    W, H = 160, 120
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.bags = self.dir / "bags"
+        make_split_recording(self.bags, splits=2, frames_per_split=6,
+                             w=self.W, h=self.H, angle_deg=35.0,
+                             extra_topics=False)
+        self.out = self.dir / "out" / "stairs"
+        self.fake = FakePredictor(height=self.H, width=self.W, radius=30,
+                                  velocity=(0.0, 0.0))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _segment(self, **kw):
+        with mock.patch.object(stairs_pipeline, "build_predictor",
+                               return_value=self.fake):
+            return stairs_pipeline.segment(
+                self.bags, topic=COLOR_TOPIC, prompt="stairs",
+                out_stem=self.out, log=lambda *_: None, **kw)
+
+    def test_segment_writes_a_complete_handoff(self):
+        self._segment()
+        for suffix in ("_stairs.json", "_masks.npz", "_frames.mp4"):
+            p = self.out.with_name(self.out.name + suffix)
+            self.assertTrue(p.exists(), suffix)
+
+    def test_segment_does_no_orientation_or_overlay(self):
+        data = self._segment()
+        self.assertEqual(data["orientation"], {})
+        self.assertFalse((self.out.with_name(self.out.name + "_overlay.mp4")).exists())
+
+    def test_analyse_runs_from_artifacts_alone(self):
+        self._segment()
+        # Deleting the bags proves analyse needs nothing but stage 1's output —
+        # this is what lets it run on a different machine.
+        import shutil
+        shutil.rmtree(self.bags)
+
+        res = stairs_pipeline.analyse(self.out, log=lambda *_: None)
+        self.assertTrue(Path(res.overlay).exists())
+        self.assertIsNotNone(res.orientation.get("angle_deg_mean"))
+
+    def test_analyse_needs_no_predictor_at_all(self):
+        self._segment()
+        # build_predictor raising proves stage 2 never touches the GPU path.
+        def explode(*a, **k):
+            raise AssertionError("analyse must not build a predictor")
+        with mock.patch.object(stairs_pipeline, "build_predictor", explode):
+            stairs_pipeline.analyse(self.out, log=lambda *_: None)
+
+    def test_split_matches_a_single_machine_run(self):
+        self._segment()
+        split = stairs_pipeline.analyse(self.out, log=lambda *_: None)
+
+        whole_stem = self.dir / "out2" / "stairs"
+        with mock.patch.object(stairs_pipeline, "build_predictor",
+                               return_value=self.fake):
+            whole = stairs_pipeline.run(
+                self.bags, topic=COLOR_TOPIC, prompt="stairs",
+                out_stem=whole_stem, log=lambda *_: None)
+        self.assertEqual(split.frames, whole.frames)
+        self.assertAlmostEqual(split.orientation["angle_deg_mean"],
+                               whole.orientation["angle_deg_mean"], delta=0.01)
+
+    def test_analyse_updates_the_json_in_place(self):
+        self._segment()
+        stairs_pipeline.analyse(self.out, log=lambda *_: None)
+        d = json.loads((self.out.with_name(self.out.name + "_stairs.json")).read_text())
+        self.assertIsNotNone(d["orientation"].get("angle_deg_mean"))
+
+    def test_analyse_is_rerunnable_with_new_settings(self):
+        # The point of the split: retuning orientation must not need the model.
+        self._segment()
+        import stair_orientation as so
+        a = stairs_pipeline.analyse(self.out, log=lambda *_: None)
+        b = stairs_pipeline.analyse(
+            self.out, log=lambda *_: None,
+            orientation_cfg=so.OrientationConfig(min_dominant_share=0.99))
+        self.assertIsNotNone(a.orientation.get("angle_deg_mean"))
+        self.assertLessEqual(b.orientation.get("coverage", 1.0),
+                             a.orientation.get("coverage", 1.0))
+
+    def test_analyse_without_segment_says_so(self):
+        with self.assertRaises(FileNotFoundError) as ctx:
+            stairs_pipeline.analyse(self.dir / "never" / "ran")
+        self.assertIn("segment", str(ctx.exception))
+
+    def test_analyse_without_frames_video_says_so(self):
+        self._segment(keep_video=False)
+        with self.assertRaises(FileNotFoundError) as ctx:
+            stairs_pipeline.analyse(self.out, log=lambda *_: None)
+        self.assertIn("--keep-video", str(ctx.exception))
+
+    def test_missing_mask_sidecar_says_so(self):
+        self._segment()
+        (self.out.with_name(self.out.name + "_masks.npz")).unlink()
+        with self.assertRaises(FileNotFoundError) as ctx:
+            stairs_pipeline.analyse(self.out, log=lambda *_: None)
+        self.assertIn("Mask sidecar", str(ctx.exception))
+
+    def test_analyse_via_cli_needs_no_source_argument(self):
+        # The analyse stage runs where the bags are not, so requiring a source
+        # positional would defeat the whole point of the split.
+        self._segment()
+        code = stairs_pipeline.main(
+            stairs_pipeline.parse_args(["--stage", "analyse",
+                                        "--out", str(self.out)]))
+        self.assertEqual(code, 0)
+        self.assertTrue((self.out.with_name(self.out.name + "_overlay.mp4")).exists())
+
+    def test_stage_flags_parse(self):
+        a = stairs_pipeline.parse_args(["src", "--stage", "segment"])
+        self.assertEqual(a.stage, "segment")
+        b = stairs_pipeline.parse_args(["--stage", "analyse", "--out", "o"])
+        self.assertEqual((b.stage, b.out), ("analyse", "o"))
+
+
 class TestCli(unittest.TestCase):
     def test_list_topics_prints_them(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

Restructure the stairs segmentation pipeline to separate GPU-dependent work (SAM 3 inference) from CPU-only analysis (orientation measurement and overlay rendering). This enables running the expensive model stage on a GPU machine and post-processing on any machine with just the artifacts.

## Key Changes

- **Split `stairs_pipeline.run()` into two stages:**
  - `segment()` — runs SAM 3, extracts frames, persists masks to `*_masks.npz` and frames to `*_frames.mp4`, writes `*_stairs.json` metadata. This is the GPU stage.
  - `analyse()` — reads the three artifacts from stage 1, measures orientation, renders overlay video. No GPU needed; rerunnable with different settings.

- **Handoff format:** Stage 1 writes `*_stairs.json` (metadata), `*_masks.npz` (per-frame segmentations), and `*_frames.mp4` (video frames). Stage 2 needs only these three files, not the original source or bag.

- **New CLI tool `make_rois.py`:** Headless alternative to `pick.py` for defining ROIs from the command line:
  ```bash
  python src/make_rois.py --video input/crazyflo.mp4 \
      --start-frame 520 --end-frame 1200 \
      --roi cf1=940,234,87,57 --roi payload=1278,546,26,34
  ```
  Supports `--from-json` to amend existing files, `--drop` to remove objects, `--show` to preview.

- **Enhanced `render.py` CLI:** Add command-line overrides for trail appearance without editing code:
  - `--thickness`, `--alpha`, `--trail-window`, `--color NAME=R,G,B`, `--smooth`/`--no-smooth`
  - New `overrides_from_args()` function to collect these into a dict passed to `render()`

- **Improved `to_webm.py`:** Refactor to accept named files or directories, add `--bitrate` and `--out-dir` flags, extract `collect()` helper for flexible input handling.

- **Better `sam3_preflight.py`:** Detect Apple Silicon (MPS) separately from missing CUDA, provide specific guidance for unsupported hardware. Add `detect_backend()` to identify cuda/mps/cpu/none.

- **Comprehensive test coverage:** New `tests/test_cli.py` validates `make_rois`, `render` overrides, and `to_webm` argument parsing. New `TestStageSplit` in `tests/test_stairs_pipeline.py` verifies the two-stage split works correctly and that stage 2 truly needs no GPU.

- **Documentation:** Rewrite README to emphasize the two-job structure (motion trails vs. static structure), simplify setup instructions, clarify the workflow with the new CLI tools.

## Implementation Details

- `_render_overlay_frames()` (formerly `render_overlay()`) now takes decoded frames directly instead of a live `FrameWindow`, enabling it to run without the source media or GPU.
- `_persist_window()` copies extracted frames into a persistent MP4 that survives the temporary extraction directory.
- `_primary_from_areas()` selects the largest object by accumulated mask area, replacing the old `_largest_object()` which needed per-frame observations.
- Stage 1 stores object areas in the JSON so stage 2 can pick the primary object without re-reading all masks.
- Orientation results are stored in the JSON and updated in-place by `analyse()`, making the split transparent to the user.

https://claude.ai/code/session_01HTTAaunh2KQN2DtpVaiNkw